### PR TITLE
fix: adjust Github Pagex `index.html`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         run: cargo doc --locked --no-deps --workspace --all-features
 
       - name: Add redirect
-        run: echo '<meta http-equiv="refresh" content="0;url=charon/index.html">' > target/doc/index.html
+        run: echo '<meta http-equiv="refresh" content="0;url=pluto/index.html">' > target/doc/index.html
 
       - name: Remove lock file
         run: rm target/doc/.lock


### PR DESCRIPTION
Fix an issue introduced in #186 where the workflow that generates an `index.html` was not properly renamed so it continues to point to the `charon` crate which was renamed to `pluto`.