### PR TITLE
fix: print human-readable cli error

### DIFF
--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,10 +1,28 @@
 //! Error types for the Pluto CLI.
 
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    process::{ExitCode, Termination},
+};
+
 use thiserror::Error;
 
 /// Result type for CLI operations.
 pub type Result<T> = std::result::Result<T, CliError>;
+
+pub struct ExitResult(pub Result<()>);
+
+impl Termination for ExitResult {
+    fn report(self) -> ExitCode {
+        match self.0 {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(err) => {
+                eprintln!("Error: {}", err);
+                ExitCode::FAILURE
+            }
+        }
+    }
+}
 
 /// Errors that can occur in the Pluto CLI.
 #[derive(Error, Debug)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,8 +4,6 @@
 //! This crate provides the CLI tools and commands for managing and operating
 //! Pluto validator nodes.
 
-use std::process::{ExitCode, Termination};
-
 use clap::Parser;
 
 mod cli;
@@ -13,7 +11,7 @@ mod commands;
 mod error;
 
 use cli::{Cli, Commands, CreateCommands};
-use error::Result;
+use error::ExitResult;
 
 fn main() -> ExitResult {
     let cli = Cli::parse();
@@ -27,18 +25,4 @@ fn main() -> ExitResult {
     };
 
     ExitResult(result)
-}
-
-struct ExitResult(Result<()>);
-
-impl Termination for ExitResult {
-    fn report(self) -> ExitCode {
-        match self.0 {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(err) => {
-                eprintln!("Error: {}", err);
-                ExitCode::FAILURE
-            }
-        }
-    }
 }


### PR DESCRIPTION
Example

```
cargo run --bin pluto -- enr --data-dir ../tmp/go-charon-data 
Error: Failed to load private key: K1 utility error: Failed to decode the hex string: Odd number of digits
```

```
cargo run --bin pluto -- enr 
Error: Private key not found. If this is your first time running this client, create one with `pluto create enr`.
```