### PR TITLE
fix: dockerfile using ubuntu:24:04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /build
 COPY . .
 RUN cargo build --locked --release --package pluto-cli
 
-FROM debian:bookworm-slim AS app
+FROM ubuntu:24.04 AS app
 
 # Install runtime dependencies for TLS/HTTPS
 RUN apt-get update && \


### PR DESCRIPTION
Using the `debian:bookworm-slim ` will cause glibc mismatch since the code is built from `ubuntu:24:04` with newer glibc. 

`/app/bin/pluto: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/bin/pluto)`

This PR updates the dockerfile to use `ubuntu:24:04` 

`docker build -t pluto:local .`
`docker run --rm pluto:local version`

```
docker run --rm -v "$PWD/pluto-data:/data" pluto:local create enr --data-dir /data
docker run --rm -v "$PWD/pluto-data:/data" pluto:local enr --data-dir /data --verbose
```