### PR TITLE
ci: publish arm64 images to Dockerhub

### DIFF
--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -125,6 +125,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: build
+    if: ${{ needs.build.result == 'success' }}
 
     steps:
       - name: Download digests


### PR DESCRIPTION
Closes #219

---

Follows the official docs (https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners) on how to target multiple builds on CI.

It would be nice for someone running on arm64 to validate that the images can be pulled from Dockerhub and used as expected.