### PR TITLE
fix: update rand, ignore the RUSTSEC-2026-0097 for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -1398,7 +1398,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -2187,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2607,7 +2607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
 dependencies = [
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.3",
  "web-time",
 ]
 
@@ -3127,7 +3127,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "socket2 0.5.10",
  "thiserror 2.0.18",
@@ -3150,7 +3150,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -3545,7 +3545,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "tokio",
  "url",
  "xmltree",
@@ -5980,7 +5980,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6141,7 +6141,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6221,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6574,7 +6574,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -9114,7 +9114,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.3",
  "static_assertions",
  "web-time",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,14 @@ feature-depth = 1
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+ignore = [
+    # Unsoundness in `rand` 0.7.3 and 0.8.5 reachable only via a custom `log`
+    # logger that calls `rand::rng()` and hits a reseed during the log event.
+    # The only affected pulls are transitive: `cuckoofilter` -> `libp2p-floodsub`
+    # (stuck on 0.7.3) and `alloy-signer-local` (stuck on 0.8.5). Neither is
+    # reachable from Pluto's loggers. Remove once upstream bumps to >=0.9.3.
+    { id = "RUSTSEC-2026-0097", reason = "transitive rand <0.9.3 via cuckoofilter and alloy-signer-local; not triggerable from our code" },
+]
 unmaintained = "workspace"
 
 [licenses]


### PR DESCRIPTION
**Ignore RUSTSEC-2026-0097 (rand unsoundness)**

  `cargo deny check` started failing on RUSTSEC-2026-0097, an unsoundness advisory in rand versions >= 0.7, < 0.9.3.

**Changes**

  - Bumped rand 0.9.2 → 0.9.3 via cargo update (fixes the one instance we can patch in-place).
  - Added RUSTSEC-2026-0097 to deny.toml ignore list with justification. Two transitive copies remain pinned upstream and cannot be bumped from here:
    - rand 0.7.3 via cuckoofilter → libp2p-floodsub
    - rand 0.8.5 via alloy-signer-local (latest release)

**Why it's safe to ignore**

  - Unsoundness only, no known exploit. No CVSS score; the advisory documents UB under Stacked Borrows, not a remote-exploitable vulnerability.
  - Trigger path is not reachable from Pluto. It requires all of: a custom log logger that calls rand::rng(), hitting the 64KB reseed boundary mid-log-call, at trace level (or warn + getrandom failure). Pluto
   uses tracing and does not invoke rand from any logger.
  - Nothing actionable upstream-side yet. libp2p-floodsub and alloy-signer-local would need to release with rand >= 0.9.3 before we can drop the ignore.

**Follow-up**

  Remove the ignore entry once cuckoofilter/libp2p-floodsub and alloy-signer-local upgrade past rand 0.9.3.