### PR TITLE
fix: upgrade dependencies and fix RUSTSEC-2026-0098

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6722,9 +6722,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,10 @@ ignore = [
     # (stuck on 0.7.3) and `alloy-signer-local` (stuck on 0.8.5). Neither is
     # reachable from Pluto's loggers. Remove once upstream bumps to >=0.9.3.
     { id = "RUSTSEC-2026-0097", reason = "transitive rand <0.9.3 via cuckoofilter and alloy-signer-local; not triggerable from our code" },
+    # `multihash` 0.19.x still requires `core2` 0.4.0 and libp2p 0.56 has no
+    # compatible update that removes it yet. Remove once upstream publishes a
+    # non-yanked replacement in the current dependency line.
+    { crate = "core2@0.4.0", reason = "transitive via multihash/libp2p; no compatible non-yanked release available yet" },
 ]
 unmaintained = "workspace"
 


### PR DESCRIPTION
The `core2` is yanked: https://crates.io/crates/core2 
https://github.com/bbqsrc/core2 `This repository was archived by the owner on Apr 15, 2026. It is now read-only.`

We have to wait libp2p to update their dependencies
