### PR TITLE
ci: use local /review-pr skill for PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,20 +1,14 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [review_requested]
   issue_comment:
     types: [created]
 
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '/claude-review')) ||
-      (github.event_name == 'pull_request' &&
-       (contains(github.event.pull_request.requested_reviewers.*.login, 'claude-code') ||
-        contains(github.event.pull_request.requested_teams.*.slug, 'claude-code')))
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/claude-review')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -50,8 +50,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY }}
           track_progress: true
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: '/review-pr ${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '@claude-review')) ||
+       contains(github.event.comment.body, '/claude-review')) ||
       (github.event_name == 'pull_request' &&
        (contains(github.event.pull_request.requested_reviewers.*.login, 'claude-code') ||
         contains(github.event.pull_request.requested_teams.*.slug, 'claude-code')))

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,19 +3,18 @@ name: Claude Code Review
 on:
   pull_request:
     types: [review_requested]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Only run when a specific reviewer is requested (e.g., "claude-code" or specific team)
     if: |
-      contains(github.event.pull_request.requested_reviewers.*.login, 'claude-code') ||
-      contains(github.event.pull_request.requested_teams.*.slug, 'claude-code')
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude-review')) ||
+      (github.event_name == 'pull_request' &&
+       (contains(github.event.pull_request.requested_reviewers.*.login, 'claude-code') ||
+        contains(github.event.pull_request.requested_teams.*.slug, 'claude-code')))
 
     runs-on: ubuntu-latest
     permissions:
@@ -50,4 +49,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY }}
           track_progress: true
-          prompt: '/review-pr ${{ github.event.pull_request.number }}'
+          prompt: '/review-pr ${{ github.event.pull_request.number || github.event.issue.number }}'


### PR DESCRIPTION
## Summary

- Replaces the external `code-review` plugin (`plugin_marketplaces` + `plugins`) with the repo's own `/review-pr` skill
- Upgrades `pull-requests` permission from `read` to `write` so the skill can post inline review comments via the GitHub API