### PR TITLE
ci: fix permissions and pass GITHUB_TOKEN for review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
 
     steps:
@@ -42,5 +42,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           prompt: '/review-pr ${{ github.event.pull_request.number || github.event.issue.number }}'


### PR DESCRIPTION
## Summary

Follow-up to #331.

- `issues: read` → `write` — required for posting PR/issue comments via the GitHub API
- Added `github_token: ${{ secrets.GITHUB_TOKEN }}` — passes credentials to the `gh` CLI inside `claude-code-action` so it can authenticate when posting review comments