### PR TITLE
revert: remove github_token from claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      issues: read
       id-token: write
 
     steps:
@@ -42,6 +42,5 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           prompt: '/review-pr ${{ github.event.pull_request.number || github.event.issue.number }}'


### PR DESCRIPTION
Reverts #333.

Removes the explicit `github_token` pass-through and restores `issues: read` — the action uses its own token by default.