### PR TITLE
fix: ignore stale OutboundFailure events in bcast behaviour

### DIFF
--- a/crates/dkg/src/bcast/behaviour.rs
+++ b/crates/dkg/src/bcast/behaviour.rs
@@ -346,13 +346,15 @@ impl Behaviour {
                 }
             }
             OutEvent::OutboundFailure { op_id, failure } => {
-                if let Some(state) = self.active_broadcast.as_mut() {
-                    let failed_peer = state
+                let failed_peer = self.active_broadcast.as_mut().and_then(|state| {
+                    state
                         .sig_ops
                         .remove(&op_id)
                         .map(|sig_op| sig_op.peer)
                         .or_else(|| state.msg_ops.remove(&op_id))
-                        .unwrap_or(peer_id);
+                });
+
+                if let Some(failed_peer) = failed_peer {
                     self.complete_active_broadcast(Err(Error::OutboundFailure {
                         peer: failed_peer,
                         failure,


### PR DESCRIPTION
## Summary
- Fix a bug where a stale `OutboundFailure` from a previously failed broadcast could kill a subsequent active broadcast
- When a broadcast fails (e.g. one peer times out), in-flight requests to other peers are still running. Their eventual failures would unconditionally call `complete_active_broadcast`, taking down whatever broadcast was active at that point
- The fix checks whether the `op_id` belongs to the current broadcast before acting. If it doesn't match, the event is logged and ignored — consistent with how `SigResponse` and `MessageSent` already handle stale events

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo +nightly fmt --all --check` passes
- [x] `cargo test --workspace --all-features` passes