### PR TITLE
refactor(p2p): not allow builder to set p2p_context

### DIFF
--- a/crates/dkg/examples/bcast.rs
+++ b/crates/dkg/examples/bcast.rs
@@ -82,6 +82,7 @@ use pluto_p2p::{
     config::P2PConfig,
     gater, k1,
     p2p::{Node, NodeType},
+    p2p_context::P2PContext,
     relay::{MutableRelayReservation, RelayRouter},
 };
 use pluto_tracing::TracingConfig;
@@ -577,13 +578,14 @@ async fn main() -> Result<()> {
         disable_reuse_port: args.disable_reuse_port,
     };
 
+    let p2p_context = P2PContext::new(known_peers.clone());
     let mut component = None;
     let mut node: Node<ExampleBehaviour> = Node::new(
         p2p_config,
         key.clone(),
         NodeType::QUIC,
         args.filter_private_addrs,
-        known_peers,
+        p2p_context,
         |builder, keypair, relay_client| {
             let p2p_context = builder.p2p_context();
             let local_peer_id = keypair.public().to_peer_id();
@@ -592,15 +594,12 @@ async fn main() -> Result<()> {
                 bcast::Behaviour::new(cluster_peers.clone(), p2p_context.clone(), key.clone());
             component = Some(c);
 
-            builder
-                .with_p2p_context(p2p_context.clone())
-                .with_gater(conn_gater)
-                .with_inner(ExampleBehaviour {
-                    relay: relay_client,
-                    relay_reservation: MutableRelayReservation::new(relays.clone()),
-                    relay_router: RelayRouter::new(relays.clone(), p2p_context, local_peer_id),
-                    bcast: bcast_behaviour,
-                })
+            builder.with_gater(conn_gater).with_inner(ExampleBehaviour {
+                relay: relay_client,
+                relay_reservation: MutableRelayReservation::new(relays.clone()),
+                relay_router: RelayRouter::new(relays.clone(), p2p_context, local_peer_id),
+                bcast: bcast_behaviour,
+            })
         },
     )?;
 

--- a/crates/dkg/src/bcast/behaviour.rs
+++ b/crates/dkg/src/bcast/behaviour.rs
@@ -697,12 +697,8 @@ mod tests {
                 key,
                 NodeType::TCP,
                 false,
-                peer_ids.clone(),
-                move |builder, _keypair| {
-                    builder
-                        .with_p2p_context(p2p_context.clone())
-                        .with_inner(behaviour)
-                },
+                p2p_context.clone(),
+                move |builder, _keypair| builder.with_inner(behaviour),
             )?;
             let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", ports[index]).parse()?;
             nodes.push(LocalNode {

--- a/crates/dkg/src/nodesigs.rs
+++ b/crates/dkg/src/nodesigs.rs
@@ -569,8 +569,8 @@ mod tests {
                 key.clone(),
                 NodeType::TCP,
                 false,
-                peer_ids.clone(),
-                move |builder, _| builder.with_p2p_context(p2p_context).with_inner(behaviour),
+                p2p_context,
+                move |builder, _| builder.with_inner(behaviour),
             )?;
 
             let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", ports[index]).parse()?;

--- a/crates/p2p/examples/bootnode.rs
+++ b/crates/p2p/examples/bootnode.rs
@@ -42,6 +42,7 @@ use pluto_p2p::{
     config::P2PConfig,
     gater, k1,
     p2p::{Node, NodeType},
+    p2p_context::P2PContext,
     relay::{MutableRelayReservation, RelayRouter},
 };
 use pluto_tracing::TracingConfig;
@@ -143,7 +144,7 @@ pub async fn main() -> Result<()> {
         pk,
         NodeType::QUIC,
         false,
-        known_peers.clone(),
+        P2PContext::new(known_peers.clone()),
         |builder, keypair, relay_client| {
             let p2p_context = builder.p2p_context();
             let local_peer_id = keypair.public().to_peer_id();

--- a/crates/p2p/examples/p2p.rs
+++ b/crates/p2p/examples/p2p.rs
@@ -20,6 +20,7 @@ use pluto_p2p::{
     behaviours::pluto::PlutoBehaviourEvent,
     config::P2PConfig,
     p2p::{Node, NodeType},
+    p2p_context::P2PContext,
 };
 use tokio::signal;
 
@@ -73,13 +74,13 @@ async fn main() -> Result<()> {
 
     // Create node with composed behaviour
     // No known cluster peers in this example
-    let known_peers: Vec<libp2p::PeerId> = vec![];
+    let p2p_context = P2PContext::default();
     let mut p2p = Node::new(
         P2PConfig::default(),
         key.clone(),
         NodeType::QUIC,
         false,
-        known_peers,
+        p2p_context,
         |builder, keypair, relay_client| {
             builder
                 .with_user_agent("pluto-p2p-example/1.0.0")

--- a/crates/p2p/examples/quic_upgrade.rs
+++ b/crates/p2p/examples/quic_upgrade.rs
@@ -59,6 +59,7 @@ use pluto_p2p::{
     behaviours::pluto::PlutoBehaviourEvent,
     config::P2PConfig,
     p2p::{Node, NodeType},
+    p2p_context::P2PContext,
     quic_upgrade::QuicUpgradeEvent,
 };
 use tokio::signal;
@@ -112,7 +113,7 @@ async fn main() -> Result<()> {
         key,
         NodeType::QUIC, // Enable QUIC transport
         false,          // Don't filter private addresses (for local testing)
-        known_peers,
+        P2PContext::new(known_peers),
         |builder, _keypair, relay_client| {
             builder
                 .with_user_agent("quic-upgrade-example/1.0.0")

--- a/crates/p2p/src/behaviours/pluto.rs
+++ b/crates/p2p/src/behaviours/pluto.rs
@@ -62,8 +62,8 @@ pub struct PlutoBehaviour<B: NetworkBehaviour> {
 
 impl<B: NetworkBehaviour> PlutoBehaviour<B> {
     /// Returns a new builder for configuring a PlutoBehaviour.
-    pub fn builder() -> PlutoBehaviourBuilder<B> {
-        PlutoBehaviourBuilder::default()
+    pub fn builder(p2p_context: P2PContext) -> PlutoBehaviourBuilder<B> {
+        PlutoBehaviourBuilder::new(p2p_context)
     }
 }
 
@@ -96,24 +96,19 @@ pub struct PlutoBehaviourBuilder<B> {
     inner: Option<B>,
 }
 
-impl<B> Default for PlutoBehaviourBuilder<B> {
-    fn default() -> Self {
+impl<B: NetworkBehaviour> PlutoBehaviourBuilder<B> {
+    /// Creates a new builder with default configuration and the provided shared
+    /// P2P context.
+    pub fn new(p2p_context: P2PContext) -> Self {
         Self {
             gater: None,
             identify_protocol: DEFAULT_IDENTIFY_PROTOCOL.clone(),
             user_agent: DEFAULT_USER_AGENT.clone(),
             autonat_config: autonat::Config::default(),
-            p2p_context: P2PContext::default(),
+            p2p_context,
             quic_enabled: false,
             inner: None,
         }
-    }
-}
-
-impl<B: NetworkBehaviour> PlutoBehaviourBuilder<B> {
-    /// Creates a new builder with default configuration.
-    pub fn new() -> Self {
-        Self::default()
     }
 
     /// Returns the cloned P2P context.
@@ -167,14 +162,6 @@ impl<B: NetworkBehaviour> PlutoBehaviourBuilder<B> {
         self
     }
 
-    /// Sets the global context.
-    ///
-    /// The global context is used to store the peer store.
-    pub fn with_p2p_context(mut self, p2p_context: P2PContext) -> Self {
-        self.p2p_context = p2p_context;
-        self
-    }
-
     /// Sets whether QUIC is enabled.
     ///
     /// When enabled, the behaviour will periodically attempt to upgrade
@@ -191,7 +178,6 @@ impl<B: NetworkBehaviour> PlutoBehaviourBuilder<B> {
     /// * `key` - The keypair for this node, used for identify and autonat
     pub fn build(self, key: &Keypair) -> PlutoBehaviour<B> {
         let local_peer_id = key.public().to_peer_id();
-        self.p2p_context.set_local_peer_id(local_peer_id);
 
         let identify_config = identify::Config::new(self.identify_protocol, key.public())
             .with_agent_version(self.user_agent)

--- a/crates/p2p/src/p2p.rs
+++ b/crates/p2p/src/p2p.rs
@@ -23,8 +23,8 @@
 //!     secret_key,
 //!     NodeType::QUIC,
 //!     false, // filter_private_addrs
-//!     vec![], // known_peers
-//!     |builder, _p2p_ctx, _keypair, relay_client| {
+//!     P2PContext::default(),
+//!     |builder, _keypair, relay_client| {
 //!         builder
 //!             .with_user_agent("my-app/1.0.0")
 //!             .with_inner(relay_client)
@@ -42,8 +42,8 @@
 //!     secret_key,
 //!     NodeType::QUIC,
 //!     false, // filter_private_addrs
-//!     vec![], // known_peers
-//!     |builder, _p2p_ctx, keypair, relay_client| {
+//!     P2PContext::default(),
+//!     |builder, keypair, relay_client| {
 //!         builder
 //!             .with_user_agent("my-app/1.0.0")
 //!             .with_inner(MyBehaviour {
@@ -67,8 +67,8 @@
 //!     secret_key,
 //!     NodeType::TCP,
 //!     false, // filter_private_addrs
-//!     vec![], // known_peers
-//!     |builder, _p2p_ctx, keypair| {
+//!     P2PContext::default(),
+//!     |builder, keypair| {
 //!         builder.with_inner(
 //!             relay::Behaviour::new(keypair.public().to_peer_id(), relay_config)
 //!         )
@@ -148,6 +148,15 @@ pub enum P2PError {
     /// Failed to parse IP address.
     #[error("Failed to parse IP address: {0}")]
     FailedToParseIpAddress(#[from] std::net::AddrParseError),
+
+    /// The provided P2P context is already bound to a different local peer ID.
+    #[error("P2P context local peer ID mismatch: expected {expected}, got {actual}")]
+    LocalPeerIdMismatch {
+        /// Local peer ID derived from the node keypair.
+        expected: Box<PeerId>,
+        /// Local peer ID already bound in the shared P2P context.
+        actual: Box<PeerId>,
+    },
 }
 
 impl P2PError {
@@ -183,10 +192,10 @@ pub struct Node<B: NetworkBehaviour> {
 impl<B: NetworkBehaviour> Node<B> {
     /// Creates a new client node with relay client support.
     ///
-    /// The `behaviour_fn` receives a default `PlutoBehaviourBuilder`, the P2P
-    /// context, keypair, and relay client. It should configure the builder
-    /// (e.g., set user agent, inner behaviour) and return it. The builder
-    /// will then be finalized internally.
+    /// The `behaviour_fn` receives a `PlutoBehaviourBuilder`, keypair, and
+    /// relay client. It should configure the builder (e.g., set user agent,
+    /// inner behaviour) and return it. The builder will then be finalized
+    /// internally.
     ///
     /// # Arguments
     ///
@@ -194,7 +203,7 @@ impl<B: NetworkBehaviour> Node<B> {
     /// * `key` - Secret key for node identity
     /// * `node_type` - Transport type (TCP or QUIC)
     /// * `filter_private_addrs` - Whether to filter private addresses
-    /// * `known_peers` - List of known cluster peer IDs for metrics tracking
+    /// * `p2p_context` - Shared P2P runtime context for this node
     /// * `behaviour_fn` - Closure that configures and returns the behaviour
     ///   builder
     ///
@@ -206,8 +215,8 @@ impl<B: NetworkBehaviour> Node<B> {
     ///     secret_key,
     ///     NodeType::QUIC,
     ///     false,
-    ///     vec![peer1, peer2], // known cluster peers
-    ///     |builder, _p2p_ctx, _keypair, relay_client| {
+    ///     P2PContext::new(vec![peer1, peer2]),
+    ///     |builder, _keypair, relay_client| {
     ///         builder
     ///             .with_user_agent("my-app/1.0.0")
     ///             .with_inner(MyBehaviour { relay_client, peerinfo: ... })
@@ -219,7 +228,7 @@ impl<B: NetworkBehaviour> Node<B> {
         key: k256::SecretKey,
         node_type: NodeType,
         filter_private_addrs: bool,
-        known_peers: impl IntoIterator<Item = PeerId>,
+        p2p_context: P2PContext,
         behaviour_fn: F,
     ) -> Result<Self>
     where
@@ -230,7 +239,7 @@ impl<B: NetworkBehaviour> Node<B> {
         ) -> PlutoBehaviourBuilder<B>,
     {
         let keypair = utils::keypair_from_secret_key(key)?;
-        let p2p_context = P2PContext::new(known_peers);
+        Self::bind_local_peer_id(&p2p_context, keypair.public().to_peer_id())?;
 
         let mut node = match node_type {
             NodeType::TCP => Self::build_tcp_client(keypair, p2p_context, behaviour_fn),
@@ -247,22 +256,22 @@ impl<B: NetworkBehaviour> Node<B> {
     /// Server nodes (like relay servers) don't include relay client support
     /// since they are expected to be publicly reachable.
     ///
-    /// The `behaviour_fn` receives a default `PlutoBehaviourBuilder`, the P2P
-    /// context, and keypair. It should configure the builder (e.g., set user
-    /// agent, inner behaviour) and return it.
+    /// The `behaviour_fn` receives a `PlutoBehaviourBuilder` and keypair. It
+    /// should configure the builder (e.g., set user agent, inner behaviour)
+    /// and return it.
     pub fn new_server<F>(
         cfg: P2PConfig,
         key: k256::SecretKey,
         node_type: NodeType,
         filter_private_addrs: bool,
-        known_peers: impl IntoIterator<Item = PeerId>,
+        p2p_context: P2PContext,
         behaviour_fn: F,
     ) -> Result<Self>
     where
         F: FnOnce(PlutoBehaviourBuilder<B>, &Keypair) -> PlutoBehaviourBuilder<B>,
     {
         let keypair = utils::keypair_from_secret_key(key)?;
-        let p2p_context = P2PContext::new(known_peers);
+        Self::bind_local_peer_id(&p2p_context, keypair.public().to_peer_id())?;
 
         let mut node = match node_type {
             NodeType::TCP => Self::build_tcp_server(keypair, p2p_context, behaviour_fn),
@@ -317,6 +326,22 @@ impl<B: NetworkBehaviour> Node<B> {
         Ok(())
     }
 
+    fn bind_local_peer_id(p2p_context: &P2PContext, local_peer_id: PeerId) -> Result<()> {
+        match p2p_context.local_peer_id() {
+            Some(existing_peer_id) if existing_peer_id != local_peer_id => {
+                Err(P2PError::LocalPeerIdMismatch {
+                    expected: Box::new(local_peer_id),
+                    actual: Box::new(existing_peer_id),
+                })
+            }
+            Some(_) => Ok(()),
+            None => {
+                p2p_context.set_local_peer_id(local_peer_id);
+                Ok(())
+            }
+        }
+    }
+
     fn build_quic_client<F>(
         keypair: Keypair,
         p2p_context: P2PContext,
@@ -339,9 +364,8 @@ impl<B: NetworkBehaviour> Node<B> {
             .with_relay_client(noise::Config::new, yamux_config)
             .map_err(P2PError::failed_to_build_swarm)?
             .with_behaviour(|key, relay_client| {
-                let builder = PlutoBehaviourBuilder::default()
-                    .with_p2p_context(p2p_context.clone())
-                    .with_quic_enabled(true);
+                let builder =
+                    PlutoBehaviourBuilder::new(p2p_context.clone()).with_quic_enabled(true);
                 behaviour_fn(builder, key, relay_client).build(key)
             })
             .map_err(P2PError::failed_to_build_swarm)?
@@ -376,8 +400,7 @@ impl<B: NetworkBehaviour> Node<B> {
             .with_relay_client(noise::Config::new, yamux_config)
             .map_err(P2PError::failed_to_build_swarm)?
             .with_behaviour(|key, relay_client| {
-                let builder =
-                    PlutoBehaviourBuilder::default().with_p2p_context(p2p_context.clone());
+                let builder = PlutoBehaviourBuilder::new(p2p_context.clone());
                 behaviour_fn(builder, key, relay_client).build(key)
             })
             .map_err(P2PError::failed_to_build_swarm)?
@@ -407,8 +430,7 @@ impl<B: NetworkBehaviour> Node<B> {
             .with_dns()
             .map_err(P2PError::failed_to_build_swarm)?
             .with_behaviour(|key| {
-                let builder =
-                    PlutoBehaviourBuilder::default().with_p2p_context(p2p_context.clone());
+                let builder = PlutoBehaviourBuilder::new(p2p_context.clone());
                 behaviour_fn(builder, key).build(key)
             })
             .map_err(P2PError::failed_to_build_swarm)?
@@ -438,8 +460,7 @@ impl<B: NetworkBehaviour> Node<B> {
             .with_dns()
             .map_err(P2PError::failed_to_build_swarm)?
             .with_behaviour(|key| {
-                let builder =
-                    PlutoBehaviourBuilder::default().with_p2p_context(p2p_context.clone());
+                let builder = PlutoBehaviourBuilder::new(p2p_context.clone());
                 behaviour_fn(builder, key).build(key)
             })
             .map_err(P2PError::failed_to_build_swarm)?

--- a/crates/parsigex/examples/parsigex.rs
+++ b/crates/parsigex/examples/parsigex.rs
@@ -81,6 +81,7 @@ use pluto_p2p::{
     config::P2PConfig,
     gater, k1,
     p2p::{Node, NodeType},
+    p2p_context::P2PContext,
     peer::peer_id_from_key,
     relay::{MutableRelayReservation, RelayRouter},
 };
@@ -267,7 +268,7 @@ async fn main() -> Result<()> {
         key,
         NodeType::QUIC,
         args.filter_private_addrs,
-        known_peers.clone(),
+        P2PContext::new(known_peers.clone()),
         |builder, keypair, relay_client| {
             let p2p_context = builder.p2p_context();
             let local_peer_id = keypair.public().to_peer_id();

--- a/crates/peerinfo/examples/peerinfo.rs
+++ b/crates/peerinfo/examples/peerinfo.rs
@@ -25,6 +25,7 @@ use pluto_p2p::{
     k1,
     name::peer_name,
     p2p::{Node, NodeType},
+    p2p_context::P2PContext,
 };
 use pluto_peerinfo::{Behaviour, Config, Event, LocalPeerInfo};
 use pluto_tracing::{LokiConfig, TracingConfig};
@@ -316,13 +317,13 @@ async fn main() -> anyhow::Result<()> {
 
     // Build the node
     // No known cluster peers in this example
-    let known_peers: Vec<libp2p::PeerId> = vec![];
+    let p2p_context = P2PContext::default();
     let mut node = Node::new(
         P2PConfig::default(),
         key,
         NodeType::TCP,
         false,
-        known_peers,
+        p2p_context,
         |builder, keypair, relay_client| {
             let peer_id = keypair.public().to_peer_id();
             builder.with_inner(CombinedBehaviour {

--- a/crates/relay-server/src/p2p.rs
+++ b/crates/relay-server/src/p2p.rs
@@ -14,7 +14,10 @@ use crate::{
     config::{Config, create_relay_config},
     web::enr_server,
 };
-use pluto_p2p::p2p::{Node, NodeType};
+use pluto_p2p::{
+    p2p::{Node, NodeType},
+    p2p_context::P2PContext,
+};
 
 /// Runs a relay P2P node.
 #[instrument(skip(config, key, ct))]
@@ -25,13 +28,13 @@ pub async fn run_relay_p2p_node(
 ) -> Result<Node<relay::Behaviour>> {
     let relay_config = create_relay_config(config);
     // Relay servers don't track cluster peers - they serve all connections
-    let known_peers: Vec<libp2p::PeerId> = vec![];
+    let p2p_context = P2PContext::default();
     let mut node = Node::new_server(
         config.p2p_config.clone(),
         key.clone(),
         NodeType::TCP,
         false,
-        known_peers,
+        p2p_context,
         |builder, keypair| {
             builder.with_inner(relay::Behaviour::new(
                 keypair.public().to_peer_id(),

--- a/crates/relay-server/src/p2p.rs
+++ b/crates/relay-server/src/p2p.rs
@@ -27,14 +27,13 @@ pub async fn run_relay_p2p_node(
     ct: CancellationToken,
 ) -> Result<Node<relay::Behaviour>> {
     let relay_config = create_relay_config(config);
-    // Relay servers don't track cluster peers - they serve all connections
-    let p2p_context = P2PContext::default();
     let mut node = Node::new_server(
         config.p2p_config.clone(),
         key.clone(),
         NodeType::TCP,
         false,
-        p2p_context,
+        // Relay servers don't track cluster peers - they serve all connections.
+        P2PContext::default(),
         |builder, keypair| {
             builder.with_inner(relay::Behaviour::new(
                 keypair.public().to_peer_id(),


### PR DESCRIPTION
This fixes a `P2PContext` ownership misuseAPI in the P2P builder flow.

Previously, `Node::new` created a `P2PContext` internally while callers could also create one externally and `PlutoBehaviourBuilder` could overwrite it again. That made it possible for `Node`, `PlutoBehaviour`, and inner behaviours to accidentally use different contexts.

This change makes `P2PContext` an explicit constructor input to `Node::new` / `Node::new_server`, removes `with_p2p_context` from the builder, and moves local peer binding into `Node`.

Benefit: one node now has one authoritative shared `P2PContext`, making the API safer and preventing split state between node-level and behaviour-level components.