### PR TITLE
fix: clippy on qbft and pin rust-toolchain

### DIFF
--- a/crates/core/src/qbft/mod.rs
+++ b/crates/core/src/qbft/mod.rs
@@ -1060,7 +1060,7 @@ where
         }
 
         if (qrc.len() as i64) >= d.quorum() && has_highest_prepared {
-            qrc.extend(prepares.into_iter());
+            qrc.extend(prepares);
             return Some(qrc);
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "stable"
-version = "1.89.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Local and CI lint results could diverge because rust-toolchain.toml was not actually pinning a Rust version. It used channel = "stable" plus an unsupported version field, so different machines could run different rustc/clippy versions and surface different warnings.

This PR pins the workspace toolchain to 1.95.0 in rust-toolchain.toml and remove the invalid version key.





