### PR TITLE
fix: yaml format rust skill rust-p2p

### DIFF
--- a/.claude/skills/rust-p2p/SKILL.md
+++ b/.claude/skills/rust-p2p/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-p2p
-description: Use when implementing, reviewing, debugging, or explaining Pluto Rust libp2p code: Node/P2PContext ownership, PlutoBehaviour composition, NetworkBehaviour and ConnectionHandler protocols, relay/force-direct/quic-upgrade behaviours, peerinfo/parsigex protocol handlers, DKG protocol handlers, and P2P tests.
+description: "Use when implementing, reviewing, debugging, or explaining Pluto Rust libp2p code: Node/P2PContext ownership, PlutoBehaviour composition, NetworkBehaviour and ConnectionHandler protocols, relay/force-direct/quic-upgrade behaviours, peerinfo/parsigex protocol handlers, DKG protocol handlers, and P2P tests."
 ---
 
 # Rust P2P


### PR DESCRIPTION
Fix yaml format for rust-p2p skill