### PR TITLE
feat: add dkg runner together with CI

### DIFF
--- a/.github/workflows/dkg-runner.yml
+++ b/.github/workflows/dkg-runner.yml
@@ -16,7 +16,7 @@ on:
       timeout:
         description: "Per-ceremony TIMEOUT (seconds)"
         type: string
-        default: "180"
+        default: "120"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,9 +28,18 @@ env:
 
 jobs:
   dkg-ceremony:
-    name: 4 Charon nodes
+    name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 4 Charon nodes
+            id: 4-charon
+            pluto_nodes: 0
+            charon_nodes: 4
 
     steps:
       - name: Checkout
@@ -43,45 +52,58 @@ jobs:
           path: bin/charon
           key: charon-${{ env.CHARON_VERSION }}-linux-amd64
 
-      - name: Download and extract charon
+      - name: Install charon
         if: steps.cache-charon.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          mkdir -p bin
-          tmp=$(mktemp -d)
-          curl -fLsS "${CHARON_URL}" -o "${tmp}/charon.tar.gz"
-          tar -xzf "${tmp}/charon.tar.gz" -C "${tmp}"
-          bin_path=$(find "${tmp}" -type f -name charon -perm -u+x | head -1)
-          if [[ -z "${bin_path}" ]]; then
-            echo "::error::charon binary not found inside extracted tarball"
-            ls -R "${tmp}"
-            exit 1
-          fi
-          install -m 0755 "${bin_path}" bin/charon
+        run: ./scripts/dkg-runner/ci/install-charon.sh bin
 
       - name: Verify charon
         run: ./bin/charon version
 
-      - name: Run DKG ceremony (4 charon nodes)
+      - name: Cache cargo registry and target
+        if: matrix.pluto_nodes > 0
+        uses: Swatinem/rust-cache@v2
+
+      - name: Update apt package list
+        if: matrix.pluto_nodes > 0
+        run: sudo apt-get update
+
+      - name: Install protobuf
+        if: matrix.pluto_nodes > 0
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: protobuf-compiler=3.21.12*
+          version: 3.21.12
+
+      - name: Install oas3-gen
+        if: matrix.pluto_nodes > 0
+        run: cargo install oas3-gen@0.24.0
+
+      - name: Build pluto
+        if: matrix.pluto_nodes > 0
+        run: cargo build -p pluto-cli
+
+      - name: Run DKG ceremony
         env:
           CI: "true"
           NODES: "4"
           THRESHOLD: "3"
-          PLUTO_NODES: "0"
-          CHARON_NODES: "4"
+          PLUTO_NODES: ${{ matrix.pluto_nodes }}
+          CHARON_NODES: ${{ matrix.charon_nodes }}
           CHARON_BIN: ${{ github.workspace }}/bin/charon
-          TIMEOUT: ${{ inputs.timeout || '180' }}
+          PLUTO_BIN: ${{ github.workspace }}/target/debug/pluto
+          TIMEOUT: ${{ inputs.timeout || '120' }}
         run: ./scripts/dkg-runner/run.sh
 
-      - name: List collected outputs
-        if: success()
-        run: ls -la /tmp/dkg-run/output/ /tmp/dkg-run/output/node-*/ || true
+      - name: Verify ceremony outputs
+        env:
+          NODES: "4"
+        run: ./scripts/dkg-runner/ci/verify-output.sh
 
       - name: Upload work dir on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: dkg-run-${{ github.run_id }}
+          name: dkg-run-${{ github.run_id }}-${{ matrix.id }}
           path: /tmp/dkg-run
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/dkg-runner.yml
+++ b/.github/workflows/dkg-runner.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CHARON_VERSION: v1.7.1
   CHARON_URL: https://github.com/ObolNetwork/charon/releases/download/v1.7.1/charon-v1.7.1-linux-amd64.tar.gz

--- a/.github/workflows/dkg-runner.yml
+++ b/.github/workflows/dkg-runner.yml
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   CHARON_VERSION: v1.7.1

--- a/.github/workflows/dkg-runner.yml
+++ b/.github/workflows/dkg-runner.yml
@@ -1,0 +1,87 @@
+name: DKG runner integration
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "scripts/dkg-runner/**"
+      - ".github/workflows/dkg-runner.yml"
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "scripts/dkg-runner/**"
+      - ".github/workflows/dkg-runner.yml"
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: "Per-ceremony TIMEOUT (seconds)"
+        type: string
+        default: "180"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHARON_VERSION: v1.7.1
+  CHARON_URL: https://github.com/ObolNetwork/charon/releases/download/v1.7.1/charon-v1.7.1-linux-amd64.tar.gz
+
+jobs:
+  dkg-ceremony:
+    name: 4 Charon nodes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache charon binary
+        id: cache-charon
+        uses: actions/cache@v4
+        with:
+          path: bin/charon
+          key: charon-${{ env.CHARON_VERSION }}-linux-amd64
+
+      - name: Download and extract charon
+        if: steps.cache-charon.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          tmp=$(mktemp -d)
+          curl -fLsS "${CHARON_URL}" -o "${tmp}/charon.tar.gz"
+          tar -xzf "${tmp}/charon.tar.gz" -C "${tmp}"
+          bin_path=$(find "${tmp}" -type f -name charon -perm -u+x | head -1)
+          if [[ -z "${bin_path}" ]]; then
+            echo "::error::charon binary not found inside extracted tarball"
+            ls -R "${tmp}"
+            exit 1
+          fi
+          install -m 0755 "${bin_path}" bin/charon
+
+      - name: Verify charon
+        run: ./bin/charon version
+
+      - name: Run DKG ceremony (4 charon nodes)
+        env:
+          CI: "true"
+          NODES: "4"
+          THRESHOLD: "3"
+          PLUTO_NODES: "0"
+          CHARON_NODES: "4"
+          CHARON_BIN: ${{ github.workspace }}/bin/charon
+          TIMEOUT: ${{ inputs.timeout || '180' }}
+        run: ./scripts/dkg-runner/run.sh
+
+      - name: List collected outputs
+        if: success()
+        run: ls -la /tmp/dkg-run/output/ /tmp/dkg-run/output/node-*/ || true
+
+      - name: Upload work dir on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dkg-run-${{ github.run_id }}
+          path: /tmp/dkg-run
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/dkg-runner.yml
+++ b/.github/workflows/dkg-runner.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache cargo registry and target
         if: matrix.pluto_nodes > 0
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Update apt package list
         if: matrix.pluto_nodes > 0
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install protobuf
         if: matrix.pluto_nodes > 0
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: protobuf-compiler=3.21.12*
           version: 3.21.12

--- a/scripts/dkg-runner/README.md
+++ b/scripts/dkg-runner/README.md
@@ -1,0 +1,157 @@
+# DKG Runner
+
+Shell scripts for running a complete DKG ceremony with a configurable mix of Pluto and Charon nodes.
+
+## Prerequisites
+
+- `charon` binary on your `$PATH` (used for `create dkg`, and for any Charon nodes in the ceremony)
+- Pluto binary built (only required if `PLUTO_NODES > 0`): `cargo build -p pluto-cli`
+- Relay server reachable (default: `https://0.relay.obol.tech`)
+
+## Quick start
+
+```bash
+# From repo root — 2 Pluto + 2 Charon (defaults)
+./scripts/dkg-runner/run.sh
+
+# All Charon, 4 nodes (works today; Pluto DKG not yet ready)
+PLUTO_NODES=0 CHARON_NODES=4 ./scripts/dkg-runner/run.sh
+
+# All Pluto, 4 nodes
+PLUTO_NODES=4 CHARON_NODES=0 ./scripts/dkg-runner/run.sh
+
+# 1 Pluto + 3 Charon
+NODES=4 THRESHOLD=3 PLUTO_NODES=1 CHARON_NODES=3 ./scripts/dkg-runner/run.sh
+
+# Run a single node manually after setup
+./scripts/dkg-runner/setup.sh
+./scripts/dkg-runner/run-node.sh 0 charon
+./scripts/dkg-runner/run-node.sh 1 pluto
+
+# Release binary, custom relay, longer timeout
+PLUTO_BIN=./target/release/pluto \
+RELAY_URL=https://0.relay.obol.tech \
+TIMEOUT=300 \
+./scripts/dkg-runner/run.sh
+
+# Keep nodes running after a successful ceremony for inspection
+KEEP_NODES=1 ./scripts/dkg-runner/run.sh
+
+# CI invocation: quiet logging, all-Charon, fail fast on timeout
+CI=true PLUTO_NODES=0 CHARON_NODES=4 TIMEOUT=180 \
+    ./scripts/dkg-runner/run.sh
+
+# Run multiple times back-to-back
+for i in $(seq 1 5); do ./scripts/dkg-runner/run.sh; done
+```
+
+## Configuration
+
+All variables are optional. Set them in the environment before calling any script.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NODES` | `4` | Total node count |
+| `THRESHOLD` | `3` | Min shares required to reconstruct the key |
+| `PLUTO_NODES` | `2` | How many slots use the Pluto binary (fills slots 0…N-1) |
+| `CHARON_NODES` | `2` | How many slots use the Charon binary (fills remaining slots) |
+| `RELAY_URL` | `https://0.relay.obol.tech` | Relay ENR endpoint passed to the DKG nodes |
+| `NETWORK` | `holesky` | Ethereum network for the cluster definition |
+| `FEE_RECIPIENT` | `0xDeaDBeef…` | Fee recipient address for the cluster |
+| `WITHDRAWAL_ADDR` | `0xDeaDBeef…` | Withdrawal address for the cluster |
+| `TIMEOUT` | `120` | Seconds to wait before declaring the ceremony failed |
+| `PLUTO_BIN` | `./target/debug/pluto` | Path to the Pluto binary (only required when `PLUTO_NODES > 0`) |
+| `CHARON_BIN` | `charon` | Path to the Charon binary |
+| `WORK_DIR` | `/tmp/dkg-run` | Scratch directory — wiped at the start of every run |
+| `KEEP_NODES` | `0` | Leave node processes running after a successful ceremony when set to `1`/`true`/`yes`/`on` |
+| `CI` | _(unset)_ | When truthy, suppresses per-node tee to stdout; logs go to `WORK_DIR/node-*/node.log` only |
+
+`PLUTO_NODES + CHARON_NODES` must equal `NODES`.
+
+## What happens during a run
+
+| Phase | Script | Action |
+|-------|--------|--------|
+| 1 | `setup.sh` | Wipes `WORK_DIR`, creates `node-0/`…`node-N/` data dirs, generates a p2p key + ENR for each node (`pluto create enr` / `charon create enr`), then runs `charon create dkg --operator-enrs=…` |
+| 2 | `start-nodes.sh` | Starts Pluto nodes (slots 0…PLUTO_NODES-1) and Charon nodes (remaining slots) as background processes, each in its own process group; logs to `node-N/node.log` |
+| 3 | `monitor.sh` | Waits for `cluster-lock.json` to appear in every node's data dir; exits 0 on completion, 1 on timeout (with the tail of each `node.log` dumped to stderr) |
+| 4 | *(inline)* | Sends SIGTERM to each node's process group unless `KEEP_NODES` is enabled |
+| 5 | `collect.sh` | Copies keystores and `cluster-lock.json` to `WORK_DIR/output/`; prints a summary |
+
+On success, outputs are under `$WORK_DIR/output/`. On failure or timeout, partial outputs are still collected and `WORK_DIR` is preserved for inspection. `run.sh` never deletes `WORK_DIR`; use `./scripts/dkg-runner/reset.sh` when you're done.
+
+If `KEEP_NODES` is enabled, successful runs leave the node processes running.
+
+Ctrl-C at any point kills all node process groups cleanly via the SIGINT trap; `WORK_DIR` is preserved.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `run.sh` | Main entry point — runs all phases in order |
+| `setup.sh` | Creates the cluster definition and data directories |
+| `start-nodes.sh` | Launches node processes in the background (each in its own process group) |
+| `run-node.sh` | Runs a single node in the foreground: `run-node.sh <index> <pluto\|charon>` |
+| `monitor.sh` | Waits for ceremony completion or timeout |
+| `collect.sh` | Gathers keystores and lock file into `output/` |
+| `reset.sh` | Kills all nodes and removes `WORK_DIR` (the explicit cleanup tool) |
+| `config.sh` | Shared env-var defaults sourced by every script |
+| `lib.sh` | Shared helpers (logging, binary checks, process-group kill) |
+
+Each script is independently runnable if you need to step through phases manually:
+
+```bash
+# Step through manually
+./scripts/dkg-runner/setup.sh
+./scripts/dkg-runner/start-nodes.sh
+./scripts/dkg-runner/run-node.sh 0 pluto
+./scripts/dkg-runner/monitor.sh
+./scripts/dkg-runner/collect.sh
+./scripts/dkg-runner/reset.sh
+```
+
+## Logs
+
+Each node writes to `$WORK_DIR/node-N/node.log`. To tail all logs live in a second terminal:
+
+```bash
+tail -f /tmp/dkg-run/node-*/node.log
+```
+
+## CI
+
+The runner is non-interactive when `CI=true` (or any truthy value) is set:
+
+- Per-node stdout/stderr is written to `node-*/node.log` only — not duplicated to the controlling terminal.
+- On timeout, the tail of every `node.log` is dumped to stderr automatically.
+- `WORK_DIR` is preserved on every exit path, so you can upload it as a build artifact.
+- Exit codes: `0` success, `1` failure/timeout, `130` interrupted.
+
+A typical GitHub Actions step:
+
+```yaml
+- name: Run DKG ceremony
+  env:
+    CI: "true"
+    PLUTO_NODES: 0
+    CHARON_NODES: 4
+    TIMEOUT: 180
+  run: ./scripts/dkg-runner/run.sh
+
+- name: Upload DKG work dir on failure
+  if: failure()
+  uses: actions/upload-artifact@v4
+  with:
+    name: dkg-run
+    path: /tmp/dkg-run
+```
+
+## Troubleshooting
+
+**`PLUTO_NODES + CHARON_NODES must equal NODES`** — check your env vars add up.
+
+**`cluster-definition.json not found`** — `charon create dkg` may have written the file under a different path. Check `$WORK_DIR` manually.
+
+**Ceremony times out** — increase `TIMEOUT`, check relay connectivity, and read the per-node log tails that `monitor.sh` prints to stderr on timeout. Full logs remain at `$WORK_DIR/node-*/node.log`.
+
+**Pluto binary not found** — build first with `cargo build -p pluto-cli`, or set `PLUTO_BIN` to the correct path. Note that `PLUTO_BIN` is only required when `PLUTO_NODES > 0`.

--- a/scripts/dkg-runner/ci/install-charon.sh
+++ b/scripts/dkg-runner/ci/install-charon.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# install-charon.sh — Downloads and installs the Charon binary from a release tarball.
+#
+# Usage:
+#   CHARON_URL=https://... ./install-charon.sh [install_dir]
+#
+# Required env:
+#   CHARON_URL — full URL to the Charon .tar.gz release archive.
+#
+# Optional argument:
+#   install_dir — destination directory (default: bin). Created if missing.
+#
+# The binary is installed as ${install_dir}/charon (mode 0755).
+# Exits non-zero on download, extract, or binary-discovery failure.
+
+set -euo pipefail
+
+if [[ -z "${CHARON_URL:-}" ]]; then
+    echo "::error::CHARON_URL is required" >&2
+    exit 1
+fi
+
+install_dir="${1:-bin}"
+mkdir -p "${install_dir}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+echo "Downloading ${CHARON_URL}"
+curl -fLsS "${CHARON_URL}" -o "${tmp}/charon.tar.gz"
+
+echo "Extracting tarball"
+tar -xzf "${tmp}/charon.tar.gz" -C "${tmp}"
+
+bin_path=$(find "${tmp}" -type f \( -name charon -o -name 'charon-*' \) ! -name '*.tar.gz' | head -1)
+if [[ -z "${bin_path}" ]]; then
+    echo "::error::charon binary not found inside extracted tarball" >&2
+    ls -R "${tmp}" >&2
+    exit 1
+fi
+
+install -m 0755 "${bin_path}" "${install_dir}/charon"
+echo "Installed ${install_dir}/charon"

--- a/scripts/dkg-runner/ci/verify-output.sh
+++ b/scripts/dkg-runner/ci/verify-output.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# verify-output.sh — Verifies that a DKG ceremony produced all expected files.
+#
+# Usage:
+#   ./verify-output.sh
+#
+# Env:
+#   WORK_DIR — scratch directory used by run.sh (default: /tmp/dkg-run).
+#   NODES    — total number of nodes in the ceremony  (default: 4).
+#
+# Checks, for each node-${i} under ${WORK_DIR}/output:
+#   - cluster-lock.json exists and is non-empty
+#   - at least one keystore-*.json exists
+#
+# Exits 0 if every node passes, 1 otherwise. Failures are reported to stderr
+# using the GitHub Actions ::error:: annotation format.
+
+set -euo pipefail
+
+WORK_DIR="${WORK_DIR:-/tmp/dkg-run}"
+NODES="${NODES:-4}"
+OUTPUT_DIR="${WORK_DIR}/output"
+
+if [[ ! -d "${OUTPUT_DIR}" ]]; then
+    echo "::error::output directory not found: ${OUTPUT_DIR}" >&2
+    exit 1
+fi
+
+failures=0
+for (( i = 0; i < NODES; i++ )); do
+    node_dir="${OUTPUT_DIR}/node-${i}"
+
+    if [[ ! -s "${node_dir}/cluster-lock.json" ]]; then
+        echo "::error::node-${i}: missing or empty cluster-lock.json" >&2
+        failures=$(( failures + 1 ))
+    fi
+
+    if ! compgen -G "${node_dir}/keystore-*.json" > /dev/null; then
+        echo "::error::node-${i}: no keystore-*.json files" >&2
+        failures=$(( failures + 1 ))
+    fi
+done
+
+if (( failures > 0 )); then
+    echo "::error::${failures} verification check(s) failed" >&2
+    exit 1
+fi
+
+echo "All ${NODES} nodes produced cluster-lock.json and at least one keystore."

--- a/scripts/dkg-runner/collect.sh
+++ b/scripts/dkg-runner/collect.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# collect.sh — Gathers keystore and cluster-lock files from node directories.
+#
+# Usage: ./collect.sh
+#
+# Copies keystore-*.json and cluster-lock.json from each node data directory
+# into ${WORK_DIR}/output/, then prints a summary of which nodes produced
+# outputs and which did not.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="collect"
+
+OUTPUT_DIR="${WORK_DIR}/output"
+mkdir -p "${OUTPUT_DIR}"
+
+log_info "Collecting outputs into ${OUTPUT_DIR}"
+
+nodes_with_keystores=()
+nodes_without_keystores=()
+nodes_with_lock=()
+nodes_without_lock=()
+
+for (( i = 0; i < NODES; i++ )); do
+    node_dir="${WORK_DIR}/node-${i}"
+    node_label="node-${i}"
+    node_out="${OUTPUT_DIR}/${node_label}"
+    mkdir -p "${node_out}"
+
+    # Pluto writes keystores under validator_keys/, Charon writes them flat
+    # in the data dir.  Handle both layouts.
+    keystore_count=0
+
+    if compgen -G "${node_dir}/validator_keys/keystore-*.json" > /dev/null 2>&1; then
+        cp "${node_dir}"/validator_keys/keystore-*.json "${node_out}/"
+        keystore_count=$(ls "${node_dir}"/validator_keys/keystore-*.json 2>/dev/null | wc -l | tr -d ' ')
+    fi
+
+    if compgen -G "${node_dir}/keystore-*.json" > /dev/null 2>&1; then
+        cp "${node_dir}"/keystore-*.json "${node_out}/"
+        keystore_count=$(( keystore_count + $(ls "${node_dir}"/keystore-*.json 2>/dev/null | wc -l | tr -d ' ') ))
+    fi
+
+    if (( keystore_count > 0 )); then
+        nodes_with_keystores+=("${node_label} (${keystore_count} keystore(s))")
+    else
+        nodes_without_keystores+=("${node_label}")
+    fi
+
+    if [[ -f "${node_dir}/cluster-lock.json" ]]; then
+        cp "${node_dir}/cluster-lock.json" "${node_out}/cluster-lock.json"
+        nodes_with_lock+=("${node_label}")
+    else
+        nodes_without_lock+=("${node_label}")
+    fi
+done
+
+# `${arr[@]+"${arr[@]}"}` is the canonical guard for safely expanding an array
+# under `set -u` when it might be empty.
+
+echo ""
+log_info "=== Summary ==="
+log_info "Nodes WITH keystores (${#nodes_with_keystores[@]}):"
+for entry in ${nodes_with_keystores[@]+"${nodes_with_keystores[@]}"}; do
+    log_info "            ${entry}"
+done
+
+if (( ${#nodes_without_keystores[@]} > 0 )); then
+    log_info "Nodes WITHOUT keystores (${#nodes_without_keystores[@]}):"
+    for entry in "${nodes_without_keystores[@]}"; do
+        log_info "            ${entry}"
+    done
+fi
+
+log_info "Nodes WITH cluster-lock (${#nodes_with_lock[@]}):"
+for entry in ${nodes_with_lock[@]+"${nodes_with_lock[@]}"}; do
+    log_info "            ${entry}"
+done
+
+if (( ${#nodes_without_lock[@]} > 0 )); then
+    log_info "Nodes WITHOUT cluster-lock (${#nodes_without_lock[@]}):"
+    for entry in "${nodes_without_lock[@]}"; do
+        log_info "            ${entry}"
+    done
+fi
+
+log_info "Output directory: ${OUTPUT_DIR}"

--- a/scripts/dkg-runner/config.sh
+++ b/scripts/dkg-runner/config.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# config.sh — shared environment defaults for the DKG runner scripts.
+# Source this file at the top of every script in this directory.
+#
+# All variables can be overridden by setting them in the environment before
+# invoking any script.
+
+: "${NODES:=4}"
+: "${THRESHOLD:=3}"
+: "${PLUTO_NODES:=2}"
+: "${CHARON_NODES:=2}"
+: "${RELAY_URL:=https://0.relay.obol.tech}"
+: "${TIMEOUT:=120}"
+: "${PLUTO_BIN:=./target/debug/pluto}"
+: "${CHARON_BIN:=charon}"
+: "${WORK_DIR:=/tmp/dkg-run}"
+: "${KEEP_NODES:=0}"
+: "${NETWORK:=holesky}"
+: "${FEE_RECIPIENT:=0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF}"
+: "${WITHDRAWAL_ADDR:=0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF}"

--- a/scripts/dkg-runner/lib.sh
+++ b/scripts/dkg-runner/lib.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# lib.sh — shared helpers for the DKG runner scripts.
+# Source after config.sh. Each script should set LOG_PREFIX before logging.
+
+# Truthy check: 1/true/yes/on (case-insensitive).
+is_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|True|yes|YES|Yes|on|ON|On) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# CI-mode: true when CI env var is truthy.
+is_ci() {
+    is_truthy "${CI:-}"
+}
+
+log_info() {
+    printf '[%s] %s\n' "${LOG_PREFIX:-script}" "$*"
+}
+
+log_err() {
+    printf '[%s] ERROR: %s\n' "${LOG_PREFIX:-script}" "$*" >&2
+}
+
+log_warn() {
+    printf '[%s] WARN: %s\n' "${LOG_PREFIX:-script}" "$*" >&2
+}
+
+# Verify a binary exists and is executable (path or PATH-resolvable name).
+require_bin() {
+    local label="${1}"
+    local bin="${2}"
+    if [[ -x "${bin}" ]] || command -v "${bin}" >/dev/null 2>&1; then
+        return 0
+    fi
+    log_err "${label} binary not found or not executable: ${bin}"
+    return 1
+}
+
+# Run '<bin> create enr --data-dir=<dir>' and echo the captured ENR line.
+# Returns 1 (with diagnostics) if the command fails or no ENR line is found.
+generate_enr() {
+    local bin="${1}"
+    local data_dir="${2}"
+    local label="${3}"
+    local output
+    if ! output=$("${bin}" create enr --data-dir="${data_dir}" 2>&1); then
+        log_err "${label}: 'create enr' failed:"
+        printf '%s\n' "${output}" >&2
+        return 1
+    fi
+    local enr
+    enr=$(printf '%s\n' "${output}" | grep -E '^enr:' | head -1 || true)
+    if [[ -z "${enr}" ]]; then
+        log_err "${label}: failed to extract ENR from 'create enr' output:"
+        printf '%s\n' "${output}" >&2
+        return 1
+    fi
+    printf '%s\n' "${enr}"
+}
+
+# Send SIGTERM to each PGID listed in <file>, wait up to <grace> seconds for the
+# groups to exit, then SIGKILL any survivors. Missing file is a no-op.
+# Args: <pgid-file> [grace-seconds]
+kill_pgids() {
+    local file="${1}"
+    local grace="${2:-5}"
+    [[ -f "${file}" ]] || return 0
+
+    local pgid
+    while IFS= read -r pgid; do
+        [[ -z "${pgid}" ]] && continue
+        if kill -0 -- "-${pgid}" 2>/dev/null; then
+            kill -TERM -- "-${pgid}" 2>/dev/null || true
+        fi
+    done < "${file}"
+
+    local waited=0
+    while (( waited < grace )); do
+        local alive=0
+        while IFS= read -r pgid; do
+            [[ -z "${pgid}" ]] && continue
+            if kill -0 -- "-${pgid}" 2>/dev/null; then
+                alive=1
+                break
+            fi
+        done < "${file}"
+        (( alive == 0 )) && return 0
+        sleep 1
+        waited=$(( waited + 1 ))
+    done
+
+    while IFS= read -r pgid; do
+        [[ -z "${pgid}" ]] && continue
+        if kill -0 -- "-${pgid}" 2>/dev/null; then
+            log_warn "SIGKILL -> PGID ${pgid} (did not exit in ${grace}s)"
+            kill -KILL -- "-${pgid}" 2>/dev/null || true
+        fi
+    done < "${file}"
+}

--- a/scripts/dkg-runner/monitor.sh
+++ b/scripts/dkg-runner/monitor.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# monitor.sh — Waits for cluster-lock.json to appear in every node's data dir.
+#
+# Usage: ./monitor.sh
+#
+# Completion is detected by the existence of the canonical DKG output
+# (cluster-lock.json) in each node's data directory — the artifact that
+# collect.sh ultimately copies out.  This is independent of log formatting
+# and survives differences between Charon and Pluto.
+#
+# Exit codes:
+#   0 — every node produced cluster-lock.json before TIMEOUT.
+#   1 — timed out; the tail of each node log is dumped to stderr for CI debug.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="monitor"
+
+POLL_INTERVAL=2
+TAIL_LINES=30
+
+log_info "Waiting for ${NODES} nodes (timeout: ${TIMEOUT}s)"
+log_info "Completion = cluster-lock.json present in ${WORK_DIR}/node-*/"
+
+start_time="${SECONDS}"
+last_count=-1
+
+while true; do
+    elapsed=$(( SECONDS - start_time ))
+    done_count=0
+    for (( i = 0; i < NODES; i++ )); do
+        if [[ -f "${WORK_DIR}/node-${i}/cluster-lock.json" ]]; then
+            done_count=$(( done_count + 1 ))
+        fi
+    done
+
+    if (( done_count >= NODES )); then
+        log_info "All ${NODES} nodes completed (${elapsed}s)"
+        exit 0
+    fi
+
+    if (( elapsed >= TIMEOUT )); then
+        log_err "TIMEOUT after ${elapsed}s — ${done_count}/${NODES} nodes completed"
+        for (( i = 0; i < NODES; i++ )); do
+            log_path="${WORK_DIR}/node-${i}/node.log"
+            if [[ -f "${log_path}" ]]; then
+                printf '\n[monitor] === tail -n %d node-%d/node.log ===\n' \
+                    "${TAIL_LINES}" "${i}" >&2
+                tail -n "${TAIL_LINES}" "${log_path}" >&2 || true
+            else
+                printf '\n[monitor] === node-%d/node.log: missing ===\n' "${i}" >&2
+            fi
+        done
+        exit 1
+    fi
+
+    # Only print progress when the count changes — keeps CI logs tidy.
+    if (( done_count != last_count )); then
+        log_info "${done_count}/${NODES} nodes done (${elapsed}s elapsed)"
+        last_count="${done_count}"
+    fi
+    sleep "${POLL_INTERVAL}"
+done

--- a/scripts/dkg-runner/reset.sh
+++ b/scripts/dkg-runner/reset.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# reset.sh — Kills all running node process groups and removes WORK_DIR.
+#
+# Usage: ./reset.sh
+#
+# Reads PGIDs from ${WORK_DIR}/pids and signals the whole process group of each
+# node (SIGTERM, then SIGKILL after a short grace period).  Finally removes
+# WORK_DIR.  This is the explicit cleanup tool — run.sh does not call it on
+# failure, so partial outputs are preserved for debugging until you ask for
+# them to be wiped.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="reset"
+
+PID_FILE="${WORK_DIR}/pids"
+GRACE_PERIOD=5
+
+if [[ -f "${PID_FILE}" ]]; then
+    log_info "Stopping node process groups listed in ${PID_FILE}"
+    kill_pgids "${PID_FILE}" "${GRACE_PERIOD}"
+else
+    log_info "No PID file at ${PID_FILE} — nothing to kill"
+fi
+
+if [[ -d "${WORK_DIR}" ]]; then
+    log_info "Removing work directory: ${WORK_DIR}"
+    rm -rf "${WORK_DIR}"
+fi
+log_info "Done."

--- a/scripts/dkg-runner/run-node.sh
+++ b/scripts/dkg-runner/run-node.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# run-node.sh — Runs a single DKG node in the foreground.
+#
+# Usage:
+#   ./run-node.sh <node-index> <pluto|charon>
+#   ./run-node.sh 0 charon
+#   ./run-node.sh 1 pluto
+#
+# Prerequisite:
+#   setup.sh must already have created WORK_DIR/cluster-definition.json and the
+#   per-node data directories / ENR keys.
+#
+# Environment variables (all optional; defaults shown):
+#   Same as config.sh, notably:
+#   PLUTO_BIN=./target/debug/pluto
+#   CHARON_BIN=charon
+#   WORK_DIR=/tmp/dkg-run
+#   RELAY_URL=https://0.relay.obol.tech
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="run-node"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    grep '^#' "${BASH_SOURCE[0]}" | grep -v '#!/' | sed 's/^# \?//'
+    exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+    log_err "expected exactly 2 arguments: <node-index> <pluto|charon>"
+    exit 1
+fi
+
+NODE_INDEX="${1}"
+NODE_KIND="${2}"
+DEF_FILE="${WORK_DIR}/cluster-definition.json"
+DATA_DIR="${WORK_DIR}/node-${NODE_INDEX}"
+LOG_FILE="${DATA_DIR}/node.log"
+
+if ! [[ "${NODE_INDEX}" =~ ^[0-9]+$ ]]; then
+    log_err "node-index must be a non-negative integer"
+    exit 1
+fi
+
+if (( NODE_INDEX < 0 || NODE_INDEX >= NODES )); then
+    log_err "node-index (${NODE_INDEX}) must be in range 0..$(( NODES - 1 ))"
+    exit 1
+fi
+
+if [[ ! -f "${DEF_FILE}" ]]; then
+    log_err "cluster-definition.json not found at ${DEF_FILE}"
+    if find "${WORK_DIR}" -maxdepth 1 -type d -name 'node-*' 2>/dev/null | grep -q .; then
+        log_err "setup appears incomplete or interrupted."
+        log_err "setup.sh must finish all ENR generation before run-node.sh can be used."
+    else
+        log_err "Run ./scripts/dkg-runner/setup.sh first."
+    fi
+    exit 1
+fi
+
+if [[ ! -d "${DATA_DIR}" ]]; then
+    log_err "node data directory not found at ${DATA_DIR}"
+    log_err "Run ./scripts/dkg-runner/setup.sh first."
+    exit 1
+fi
+
+case "${NODE_KIND}" in
+    pluto)  BIN="${PLUTO_BIN}" ;;
+    charon) BIN="${CHARON_BIN}" ;;
+    *)
+        log_err "node kind must be 'pluto' or 'charon'"
+        exit 1
+        ;;
+esac
+
+require_bin "${NODE_KIND}" "${BIN}" || exit 1
+
+log_info "=============================================="
+log_info "Starting single DKG node"
+log_info "  NODE_INDEX = ${NODE_INDEX}"
+log_info "  NODE_KIND  = ${NODE_KIND}"
+log_info "  BIN        = ${BIN}"
+log_info "  DEF_FILE   = ${DEF_FILE}"
+log_info "  DATA_DIR   = ${DATA_DIR}"
+log_info "  LOG_FILE   = ${LOG_FILE}"
+log_info "=============================================="
+
+"${BIN}" dkg \
+    --definition-file="${DEF_FILE}" \
+    --data-dir="${DATA_DIR}" \
+    --p2p-relays="${RELAY_URL}" \
+    2>&1 | tee "${LOG_FILE}"

--- a/scripts/dkg-runner/run.sh
+++ b/scripts/dkg-runner/run.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# run.sh — Orchestrates a complete DKG ceremony with Pluto and/or Charon nodes.
+#
+# Usage:
+#   ./run.sh [--help]
+#
+# Environment variables (all optional; defaults shown):
+#   NODES=4              Total number of nodes in the ceremony.
+#   THRESHOLD=3          Signing threshold (min shares required to reconstruct).
+#   PLUTO_NODES=2        How many of the NODES slots use the Pluto binary.
+#   CHARON_NODES=2       How many of the NODES slots use the Charon binary.
+#   RELAY_URL=https://0.relay.obol.tech
+#                        Relay ENR endpoint used by the DKG nodes.
+#   TIMEOUT=120          Seconds to wait for all nodes before aborting.
+#   PLUTO_BIN=./target/debug/pluto
+#                        Path to the Pluto binary.
+#   CHARON_BIN=charon    Path to the Charon binary.
+#   WORK_DIR=/tmp/dkg-run
+#                        Scratch directory for the run (wiped on every call).
+#   KEEP_NODES=0         Leave nodes running after a successful ceremony when
+#                        set to 1/true/yes/on.
+#   NETWORK=holesky      Ethereum network for the cluster definition.
+#   FEE_RECIPIENT=0xDeaD...
+#                        Fee recipient address passed to charon create dkg.
+#   WITHDRAWAL_ADDR=0xDeaD...
+#                        Withdrawal address passed to charon create dkg.
+#   CI=                  When truthy (1/true/yes/on), suppress per-node tee
+#                        to stdout; logs land only in WORK_DIR/node-*/node.log.
+#
+# Exit codes:
+#   0   — ceremony completed; outputs collected under WORK_DIR/output.
+#   1   — ceremony failed or timed out; WORK_DIR is preserved for debugging.
+#   130 — interrupted (SIGINT/SIGTERM); WORK_DIR is preserved.
+#
+# WORK_DIR is never deleted by run.sh.  Use ./reset.sh when you're done.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="run"
+
+# ── Argument handling ────────────────────────────────────────────────────────
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    grep '^#' "${BASH_SOURCE[0]}" | grep -v '#!/' | sed 's/^# \?//'
+    exit 0
+fi
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+if (( PLUTO_NODES + CHARON_NODES != NODES )); then
+    log_err "PLUTO_NODES (${PLUTO_NODES}) + CHARON_NODES (${CHARON_NODES}) must equal NODES (${NODES})"
+    exit 1
+fi
+
+if (( THRESHOLD > NODES )); then
+    log_err "THRESHOLD (${THRESHOLD}) cannot exceed NODES (${NODES})"
+    exit 1
+fi
+
+# ── Cleanup helpers ──────────────────────────────────────────────────────────
+
+PID_FILE="${WORK_DIR}/pids"
+
+_kill_nodes() {
+    kill_pgids "${PID_FILE}" 5
+}
+
+_on_signal() {
+    log_warn "Caught signal — killing nodes (work dir preserved at ${WORK_DIR})"
+    _kill_nodes || true
+    exit 130
+}
+
+trap '_on_signal' INT TERM
+
+# ── Main flow ────────────────────────────────────────────────────────────────
+
+log_info "=============================================="
+log_info "DKG runner starting"
+log_info "  NODES        = ${NODES}"
+log_info "  THRESHOLD    = ${THRESHOLD}"
+log_info "  PLUTO_NODES  = ${PLUTO_NODES}"
+log_info "  CHARON_NODES = ${CHARON_NODES}"
+log_info "  RELAY_URL    = ${RELAY_URL}"
+log_info "  NETWORK      = ${NETWORK}"
+log_info "  TIMEOUT      = ${TIMEOUT}s"
+log_info "  PLUTO_BIN    = ${PLUTO_BIN}"
+log_info "  CHARON_BIN   = ${CHARON_BIN}"
+log_info "  WORK_DIR     = ${WORK_DIR}"
+log_info "  KEEP_NODES   = ${KEEP_NODES}"
+log_info "  CI           = ${CI:-}"
+log_info "=============================================="
+
+log_info "--- Phase 1: Setup ---"
+"${SCRIPT_DIR}/setup.sh"
+
+log_info "--- Phase 2: Start nodes ---"
+"${SCRIPT_DIR}/start-nodes.sh"
+
+log_info "--- Phase 3: Monitor ---"
+monitor_exit=0
+"${SCRIPT_DIR}/monitor.sh" || monitor_exit=$?
+
+if (( monitor_exit != 0 )); then
+    log_err "DKG ceremony did not complete within ${TIMEOUT}s."
+    log_info "Killing nodes and collecting partial outputs..."
+    _kill_nodes || true
+    "${SCRIPT_DIR}/collect.sh" || true
+    log_info "Work dir preserved at ${WORK_DIR}. Run ${SCRIPT_DIR}/reset.sh to remove it."
+    trap - INT TERM
+    exit 1
+fi
+
+if is_truthy "${KEEP_NODES}"; then
+    log_info "--- Phase 4: Keep nodes running (ceremony complete) ---"
+else
+    log_info "--- Phase 4: Stop nodes (ceremony complete) ---"
+    _kill_nodes || true
+fi
+
+log_info "--- Phase 5: Collect outputs ---"
+"${SCRIPT_DIR}/collect.sh"
+
+log_info "=============================================="
+log_info "DKG ceremony completed successfully."
+log_info "Outputs available in: ${WORK_DIR}/output"
+log_info "Run ${SCRIPT_DIR}/reset.sh to clean up."
+if is_truthy "${KEEP_NODES}"; then
+    log_info "Node processes were left running."
+fi
+log_info "=============================================="
+
+trap - INT TERM
+exit 0

--- a/scripts/dkg-runner/setup.sh
+++ b/scripts/dkg-runner/setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# setup.sh — Initialises WORK_DIR, generates per-node keys/ENRs, then creates
+#             the cluster-definition.json via `charon create dkg`.
+#
+# Usage: ./setup.sh
+#
+# Reads configuration from config.sh (or the current environment).
+# Safe to call multiple times: WORK_DIR is wiped and recreated on every call.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="setup"
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+# charon is always required (used for `create dkg`).
+# pluto is required only when at least one slot uses it.
+require_bin "charon" "${CHARON_BIN}" || exit 1
+if (( PLUTO_NODES > 0 )); then
+    require_bin "pluto" "${PLUTO_BIN}" || exit 1
+fi
+
+# ── Wipe & recreate WORK_DIR ─────────────────────────────────────────────────
+log_info "Removing old work directory (if any): ${WORK_DIR}"
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+
+log_info "Creating per-node data directories and generating ENRs"
+
+enrs=()
+
+# ── Pluto nodes (slots 0 .. PLUTO_NODES-1) ───────────────────────────────────
+for (( i = 0; i < PLUTO_NODES; i++ )); do
+    data_dir="${WORK_DIR}/node-${i}"
+    mkdir -p "${data_dir}"
+    log_info "  Generating ENR for pluto node ${i} in ${data_dir}"
+    enr=$(generate_enr "${PLUTO_BIN}" "${data_dir}" "pluto node ${i}") || exit 1
+    log_info "  pluto node ${i}: ${enr}"
+    enrs+=("${enr}")
+done
+
+# ── Charon nodes (slots PLUTO_NODES .. NODES-1) ───────────────────────────────
+for (( i = PLUTO_NODES; i < NODES; i++ )); do
+    data_dir="${WORK_DIR}/node-${i}"
+    mkdir -p "${data_dir}"
+    log_info "  Generating ENR for charon node ${i} in ${data_dir}"
+    enr=$(generate_enr "${CHARON_BIN}" "${data_dir}" "charon node ${i}") || exit 1
+    log_info "  charon node ${i}: ${enr}"
+    enrs+=("${enr}")
+done
+
+# Join with commas in a subshell so IFS doesn't leak into the rest of the script.
+enr_list=$(IFS=','; printf '%s' "${enrs[*]}")
+log_info "Collected ${#enrs[@]} ENRs"
+
+# `charon create dkg --output-dir=DIR` writes cluster-definition.json directly
+# into DIR (not into DIR/.charon/).
+CHARON_DEF_FILE="${WORK_DIR}/cluster-definition.json"
+
+log_info "Running: ${CHARON_BIN} create dkg"
+"${CHARON_BIN}" create dkg \
+    --operator-enrs="${enr_list}" \
+    --threshold="${THRESHOLD}" \
+    --fee-recipient-addresses="${FEE_RECIPIENT}" \
+    --withdrawal-addresses="${WITHDRAWAL_ADDR}" \
+    --network="${NETWORK}" \
+    --name=test-dkg \
+    --output-dir="${WORK_DIR}"
+
+if [[ ! -f "${CHARON_DEF_FILE}" ]]; then
+    log_err "cluster-definition.json not found at ${CHARON_DEF_FILE}"
+    log_err "Files in ${WORK_DIR}:"
+    ls -la "${WORK_DIR}" >&2
+    exit 1
+fi
+
+log_info "Done. Definition file: ${CHARON_DEF_FILE}"

--- a/scripts/dkg-runner/start-nodes.sh
+++ b/scripts/dkg-runner/start-nodes.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# start-nodes.sh — Launches Pluto and Charon DKG nodes as background processes.
+#
+# Usage: ./start-nodes.sh
+#
+# Slots 0 .. PLUTO_NODES-1   are started with the Pluto binary.
+# Slots PLUTO_NODES .. NODES-1 are started with the Charon binary.
+# Each node runs in its own process group; PGIDs are appended to ${WORK_DIR}/pids
+# so reset.sh / run.sh can signal the whole tree on cleanup.
+#
+# Behaviour with CI=true: logs go to ${WORK_DIR}/node-N/node.log only (no tee
+# to stdout).  Without CI, output is also tee'd to the controlling terminal.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+LOG_PREFIX="start-nodes"
+
+DEF_FILE="${WORK_DIR}/cluster-definition.json"
+PID_FILE="${WORK_DIR}/pids"
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+require_bin "charon" "${CHARON_BIN}" || exit 1
+if (( PLUTO_NODES > 0 )); then
+    require_bin "pluto" "${PLUTO_BIN}" || exit 1
+fi
+
+if [[ ! -f "${DEF_FILE}" ]]; then
+    log_err "cluster-definition.json not found at ${DEF_FILE}"
+    log_err "Run setup.sh first."
+    exit 1
+fi
+
+# Enable job control so each backgrounded job runs in its own process group.
+# With monitor mode on, $! is the leader's PID and equals the new PGID, which
+# lets us signal the whole tree (including any descendants the binary spawns)
+# via `kill -- -PGID` in reset.sh / run.sh.
+set -m
+
+: > "${PID_FILE}"
+
+start_node() {
+    local index="${1}"
+    local bin="${2}"
+    local label="${3}"
+    local data_dir="${WORK_DIR}/node-${index}"
+    local log_file="${data_dir}/node.log"
+
+    mkdir -p "${data_dir}"
+    log_info "Starting ${label} node ${index} (bin: ${bin})"
+
+    if is_ci; then
+        # Quiet path for CI: write to log file only.
+        "${bin}" dkg \
+            --definition-file="${DEF_FILE}" \
+            --data-dir="${data_dir}" \
+            --p2p-relays="${RELAY_URL}" \
+            > "${log_file}" 2>&1 &
+    else
+        # Interactive path: tee to log file and the terminal.
+        "${bin}" dkg \
+            --definition-file="${DEF_FILE}" \
+            --data-dir="${data_dir}" \
+            --p2p-relays="${RELAY_URL}" \
+            > >(tee "${log_file}") 2>&1 &
+    fi
+
+    echo "$!" >> "${PID_FILE}"
+}
+
+for (( i = 0; i < PLUTO_NODES; i++ )); do
+    start_node "${i}" "${PLUTO_BIN}" "pluto"
+done
+
+for (( i = PLUTO_NODES; i < NODES; i++ )); do
+    start_node "${i}" "${CHARON_BIN}" "charon"
+done
+
+log_info "All ${NODES} nodes started. PGIDs written to ${PID_FILE}"


### PR DESCRIPTION
## What's this PR do?

Adds a DKG runner — a set of shell scripts (`scripts/dkg-runner/`) that drive a complete distributed key generation ceremony end-to-end — plus a GitHub Actions workflow (`.github/workflows/dkg-runner.yml`) that exercises it on every relevant push/PR.

> [!IMPORTANT]
> **Today the runner only exercises Charon nodes** (the CI matrix runs a single `4 Charon nodes` job). Pluto's DKG implementation isn't ready yet, so it is intentionally excluded from CI for now.
>
> Once Pluto DKG lands, the matrix will be extended to a **2 Pluto + 2 Charon** mixed setup (and ultimately 4-Pluto). The scripts already support `PLUTO_NODES`/`CHARON_NODES` knobs for any split — only the CI matrix entry needs to be added.

## Context

The runner is split into small composable scripts so each phase (`setup` -> `start-nodes` -> `monitor` -> `collect`) can be invoked manually for debugging or stitched together via `run.sh` for the happy path. Highlights:

- **Process-group lifecycle** — each node runs in its own process group; SIGINT/SIGTERM traps cleanly tear them all down even when the parent script is interrupted.
- **CI-friendly mode** — `CI=true` redirects per-node output to log files and dumps log tails on timeout; the work dir is preserved as a build artifact.
- **Verification** — `ci/verify-output.sh` asserts every node produced a non-empty `cluster-lock.json` and at least one `keystore-*.json`.
- **Mix-and-match nodes** — `PLUTO_NODES`/`CHARON_NODES` env vars control the split (slots 0…N-1 are Pluto, the rest Charon). Currently CI only uses `0/4`; mixed configs work locally already.

The Charon binary is downloaded from the official release tarball and cached by version key to keep CI runs fast. Action versions are pinned by commit hash per supply-chain hygiene.
