### PR TITLE
fix: set timeout for parsigex

### DIFF
--- a/crates/dkg/src/node.rs
+++ b/crates/dkg/src/node.rs
@@ -97,7 +97,9 @@ pub(crate) async fn setup_p2p(
 
             sig_types.contains(&duty.slot.inner())
         }),
-    );
+    )
+    .with_timeout(conf.timeout);
+
     let (parsigex_comp, parsigex_handle) = parsigex::Behaviour::new(parsigex_config);
 
     let (git_hash, _) = version::git_commit();


### PR DESCRIPTION
Missing this timeout: https://github.com/ObolNetwork/charon/blob/v1.7.1/dkg/dkg.go#L246