### PR TITLE
feat(bcast): add broadcast_and_wait for bcast

### DIFF
--- a/crates/dkg/src/bcast/behaviour.rs
+++ b/crates/dkg/src/bcast/behaviour.rs
@@ -22,7 +22,7 @@ use tracing::debug;
 use crate::dkgpb::v1::bcast::BCastMessage;
 
 use super::{
-    component::{BroadcastCommand, Component, Registry},
+    component::{BroadcastCommand, BroadcastResultTx, Component, Registry},
     error::{Error, Result},
     handler::{DedupStore, Handler, InEvent, OutEvent},
     protocol,
@@ -53,6 +53,7 @@ struct SigOp {
 struct BroadcastState {
     msg_id: String,
     any_msg: prost_types::Any,
+    completion_tx: Option<BroadcastResultTx>,
     signatures: Vec<Option<Vec<u8>>>,
     sig_ops: HashMap<u64, SigOp>,
     msg_ops: HashMap<u64, PeerId>,
@@ -149,9 +150,25 @@ impl Behaviour {
         self.pending_events.push_back(ToSwarm::GenerateEvent(event));
     }
 
+    fn complete_command(
+        &mut self,
+        msg_id: String,
+        completion_tx: Option<BroadcastResultTx>,
+        result: Result<()>,
+    ) {
+        if let Some(tx) = completion_tx {
+            let result_for_waiter = match &result {
+                Ok(()) => Ok(()),
+                Err(error) => Err(Error::BroadcastFailed(error.to_string())),
+            };
+            let _ = tx.send(result_for_waiter);
+        }
+        self.emit_broadcast_result(msg_id, result);
+    }
+
     fn complete_active_broadcast(&mut self, result: Result<()>) {
         if let Some(state) = self.active_broadcast.take() {
-            self.emit_broadcast_result(state.msg_id, result);
+            self.complete_command(state.msg_id, state.completion_tx, result);
         }
     }
 
@@ -160,16 +177,26 @@ impl Behaviour {
             return;
         }
 
-        let Some(BroadcastCommand { msg_id, any_msg }) = self.pending_commands.pop_front() else {
+        let Some(BroadcastCommand {
+            msg_id,
+            any_msg,
+            completion_tx,
+        }) = self.pending_commands.pop_front()
+        else {
             return;
         };
 
-        self.start_broadcast(msg_id, any_msg);
+        self.start_broadcast(msg_id, any_msg, completion_tx);
     }
 
-    fn start_broadcast(&mut self, msg_id: String, any_msg: prost_types::Any) {
+    fn start_broadcast(
+        &mut self,
+        msg_id: String,
+        any_msg: prost_types::Any,
+        completion_tx: Option<BroadcastResultTx>,
+    ) {
         let Some(local_peer_id) = self.p2p_context.local_peer_id() else {
-            self.emit_broadcast_result(msg_id, Err(Error::LocalPeerMissing));
+            self.complete_command(msg_id, completion_tx, Err(Error::LocalPeerMissing));
             return;
         };
 
@@ -180,7 +207,7 @@ impl Behaviour {
         {
             Some(index) => index,
             None => {
-                self.emit_broadcast_result(msg_id, Err(Error::LocalPeerMissing));
+                self.complete_command(msg_id, completion_tx, Err(Error::LocalPeerMissing));
                 return;
             }
         };
@@ -189,7 +216,7 @@ impl Behaviour {
         let local_signature = match protocol::sign_any(&self.secret, &any_msg) {
             Ok(signature) => signature,
             Err(error) => {
-                self.emit_broadcast_result(msg_id, Err(error));
+                self.complete_command(msg_id, completion_tx, Err(error));
                 return;
             }
         };
@@ -203,7 +230,11 @@ impl Behaviour {
             }
 
             if !self.is_connected(peer_id) {
-                self.emit_broadcast_result(msg_id, Err(Error::PeerNotConnected(*peer_id)));
+                self.complete_command(
+                    msg_id,
+                    completion_tx,
+                    Err(Error::PeerNotConnected(*peer_id)),
+                );
                 return;
             }
             sig_dispatches.push((index, *peer_id));
@@ -212,6 +243,7 @@ impl Behaviour {
         let mut state = BroadcastState {
             msg_id,
             any_msg,
+            completion_tx,
             signatures,
             sig_ops: HashMap::new(),
             msg_ops: HashMap::new(),
@@ -719,7 +751,7 @@ mod tests {
 
         running[0]
             .component
-            .broadcast("timestamp", &timestamp(10))
+            .broadcast_and_wait("timestamp", &timestamp(10))
             .await?;
 
         let receipts = wait_for_receipts(&mut receipt_rx, 2).await?;
@@ -751,10 +783,12 @@ mod tests {
             Event::BroadcastCompleted { msg_id } if msg_id == "timestamp"
         ));
 
-        running[0]
+        let error = running[0]
             .component
-            .broadcast("timestamp", &timestamp(11))
-            .await?;
+            .broadcast_and_wait("timestamp", &timestamp(11))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::BroadcastFailed(_)));
         assert!(matches!(
             wait_for_bcast_event(&mut event_rx, 0).await?,
             Event::BroadcastFailed { msg_id, error: Error::OutboundFailure { .. } }

--- a/crates/dkg/src/bcast/component.rs
+++ b/crates/dkg/src/bcast/component.rs
@@ -6,7 +6,7 @@ use futures::future::BoxFuture;
 use libp2p::PeerId;
 use prost::{Message, Name};
 use prost_types::Any;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, oneshot};
 
 use super::error::{Error, Result};
 
@@ -22,6 +22,7 @@ pub type CallbackFn<M> =
     Box<dyn Fn(PeerId, String, M) -> BoxFuture<'static, Result<()>> + Send + Sync + 'static>;
 
 pub(crate) type Registry = Arc<RwLock<HashMap<String, Arc<dyn RegisteredMessage>>>>;
+pub(crate) type BroadcastResultTx = oneshot::Sender<Result<()>>;
 
 /// Broadcast command sent from the user-facing component into the swarm-owned
 /// behaviour.
@@ -31,6 +32,8 @@ pub(crate) struct BroadcastCommand {
     pub(crate) msg_id: String,
     /// Wrapped protobuf message.
     pub(crate) any_msg: Any,
+    /// Receives terminal broadcast result when requested by the caller.
+    pub(crate) completion_tx: Option<BroadcastResultTx>,
 }
 
 /// Type-erased entry stored per registered message ID.
@@ -88,7 +91,10 @@ impl Component {
         }
     }
 
-    /// Registers a typed message ID with its validator and callback.
+    /// Registers a typed message ID before it is sent or received.
+    ///
+    /// `check` runs before this node signs an inbound signature request, and
+    /// `callback` runs after a fully signed broadcast message is validated.
     pub async fn register_message<M>(
         &self,
         msg_id: impl Into<String>,
@@ -110,10 +116,40 @@ impl Component {
         Ok(())
     }
 
-    /// Enqueues the provided message for broadcast to all configured peers.
+    /// Enqueues `msg` for reliable broadcast and returns after enqueue.
     ///
-    /// Completion is reported asynchronously through [`super::Event`].
+    /// Use this when the caller consumes [`super::Event`] separately or does
+    /// not need to wait for terminal status. Use [`Self::broadcast_and_wait`]
+    /// when the next protocol step depends on broadcast completion.
     pub async fn broadcast<M>(&self, msg_id: &str, msg: &M) -> Result<()>
+    where
+        M: Message + Name + Default + Clone + Send + Sync + 'static,
+    {
+        self.enqueue(msg_id, msg, None).await
+    }
+
+    /// Broadcasts `msg` and waits until the behaviour reports success or
+    /// failure.
+    ///
+    /// Use this for protocol steps that must not continue after enqueue only.
+    /// To make waiting cancellable, wrap this call in `tokio::select!`;
+    /// dropping the returned future leaves the broadcast running and only
+    /// drops this caller's completion notification.
+    pub async fn broadcast_and_wait<M>(&self, msg_id: &str, msg: &M) -> Result<()>
+    where
+        M: Message + Name + Default + Clone + Send + Sync + 'static,
+    {
+        let (completion_tx, completion_rx) = oneshot::channel();
+        self.enqueue(msg_id, msg, Some(completion_tx)).await?;
+        completion_rx.await.map_err(|_| Error::BehaviourClosed)?
+    }
+
+    async fn enqueue<M>(
+        &self,
+        msg_id: &str,
+        msg: &M,
+        completion_tx: Option<BroadcastResultTx>,
+    ) -> Result<()>
     where
         M: Message + Name + Default + Clone + Send + Sync + 'static,
     {
@@ -126,6 +162,7 @@ impl Component {
             .send(BroadcastCommand {
                 msg_id: msg_id.to_string(),
                 any_msg,
+                completion_tx,
             })
             .map_err(|_| Error::BehaviourClosed)?;
 

--- a/crates/dkg/src/bcast/error.rs
+++ b/crates/dkg/src/bcast/error.rs
@@ -88,6 +88,10 @@ pub enum Error {
     #[error("bcast behaviour is no longer running")]
     BehaviourClosed,
 
+    /// The broadcast operation failed after being accepted by the behaviour.
+    #[error("broadcast failed: {0}")]
+    BroadcastFailed(String),
+
     /// The outbound operation failed.
     #[error("outbound operation to {peer} failed: {failure}")]
     OutboundFailure {

--- a/crates/dkg/src/bcast/mod.rs
+++ b/crates/dkg/src/bcast/mod.rs
@@ -1,3 +1,73 @@
+//! DKG reliable-broadcast protocol.
+//!
+//! Reliable broadcast lets one peer send a typed protobuf message to every
+//! peer with signatures from the full DKG peer set. It first gathers one K1
+//! signature per peer over `sha256(type_url || value)`, verifies the complete
+//! signature set, then fans out the fully signed message. Receivers validate
+//! the signatures before dispatching the typed callback registered for that
+//! message ID.
+//!
+//! The protocol has four moving parts:
+//! - [`Component`] is the caller-facing handle. It owns the message registry
+//!   and submits outbound broadcasts to the swarm-owned [`Behaviour`].
+//! - [`Behaviour`] coordinates one active outbound broadcast at a time. It asks
+//!   peers for signatures, verifies the signature set, sends the final signed
+//!   message, and emits [`Event`] terminal status.
+//! - [`handler::Handler`] owns per-connection streams. It serves inbound
+//!   signature requests and fully signed messages, and reports outbound stream
+//!   results back to [`Behaviour`].
+//! - The typed registry maps logical message IDs to protocol-specific
+//!   validation and callback functions.
+//!
+//! High-level outbound flow:
+//!
+//! ```text
+//! caller
+//!   |
+//!   | Component::broadcast(...) or Component::broadcast_and_wait(...)
+//!   v
+//! Behaviour command queue
+//!   |
+//!   | sign local message hash
+//!   | request peer signatures over /sig
+//!   v
+//! Handler per peer
+//!   |
+//!   | collect signatures
+//!   | verify full signature set
+//!   | send signed message over /msg
+//!   v
+//! BroadcastCompleted / BroadcastFailed
+//! ```
+//!
+//! Inbound signature path:
+//! - A remote peer opens [`SIG_PROTOCOL_NAME`] and sends a signature request.
+//! - [`handler::Handler`] checks the dedup key `(peer_id, msg_id)` before
+//!   signing, so one peer cannot make this node sign conflicting hashes for the
+//!   same message ID.
+//! - The registered `check` function validates the typed message before this
+//!   node signs it.
+//! - The handler returns this node's K1 signature for the wrapped message.
+//!
+//! Inbound message path:
+//! - A remote peer opens [`MSG_PROTOCOL_NAME`] and sends the fully signed
+//!   broadcast message.
+//! - [`handler::Handler`] verifies the signature count, ordering, and K1
+//!   signatures against the configured peer list.
+//! - The registered typed callback receives the decoded message and can update
+//!   protocol state.
+//!
+//! API choice:
+//! - [`Component::broadcast`] only enqueues the broadcast. Use it when the
+//!   caller observes [`Event`] separately or intentionally does not need to
+//!   wait for terminal status.
+//! - [`Component::broadcast_and_wait`] enqueues and waits for terminal status.
+//!   Use it when the next protocol step depends on terminal send status.
+//!
+//! Keep the ownership boundary clear: [`Component`] is a lightweight handle,
+//! [`Behaviour`] owns swarm-level progress, and [`handler::Handler`] owns live
+//! streams for one connection.
+
 use std::time::Duration;
 
 use libp2p::swarm::StreamProtocol;

--- a/crates/dkg/src/dkg.rs
+++ b/crates/dkg/src/dkg.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, ffi::OsStr, num::TryFromIntError, path, time::Du
 
 use bon::Builder;
 use futures::StreamExt;
-use libp2p::{PeerId, swarm::SwarmEvent};
+use libp2p::PeerId;
 use pluto_app::{privkeylock, utils::UtilsError};
 use pluto_core::version;
 use tokio::select;
@@ -34,8 +34,7 @@ use pluto_eth2api::spec::phase0;
 use pluto_eth2util as eth2util;
 use pluto_eth2util::keymanager::{self, KeymanagerError};
 use pluto_p2p::{
-    behaviours::pluto::PlutoBehaviourEvent, bootnode::BootnodeError, config::P2PConfig,
-    k1::key_path, p2p::P2PError, peer::Peer,
+    bootnode::BootnodeError, config::P2PConfig, k1::key_path, p2p::P2PError, peer::Peer,
 };
 use pluto_tracing::TracingConfig;
 use url::Url;
@@ -585,9 +584,8 @@ async fn run_inner(conf: Config, ct: CancellationToken) -> Result<(), DkgError> 
 
     let sync_clients = handlers.sync.clone();
     let sync_server = handlers.sync_server.clone();
-    let frost_handle = handlers.frost_p2p;
     let network_ct = ct.child_token();
-    let network_task = tokio::spawn(drive_dkg_network(node, frost_handle, network_ct.clone()));
+    let network_task = tokio::spawn(drive_dkg_network(node, network_ct.clone()));
 
     let result = run_ceremony(
         &conf,
@@ -960,21 +958,12 @@ async fn start_sync_protocol(
 
 async fn drive_dkg_network(
     mut node: pluto_p2p::p2p::Node<crate::node::DkgBehaviour>,
-    frost_handle: frostp2p::FrostP2PHandle,
     cancellation: CancellationToken,
 ) {
     loop {
         tokio::select! {
             _ = cancellation.cancelled() => break,
-            event = node.select_next_some() => {
-                if let SwarmEvent::Behaviour(PlutoBehaviourEvent::Inner(
-                    crate::node::DkgBehaviourEvent::Bcast(event),
-                )) = event
-                    && let Err(error) = frost_handle.handle_bcast_event(event)
-                {
-                    debug!(%error, "Failed to forward bcast event to FROST transport");
-                }
-            }
+            _ = node.select_next_some() => {}
         }
     }
 }

--- a/crates/dkg/src/frost.rs
+++ b/crates/dkg/src/frost.rs
@@ -124,9 +124,6 @@ pub enum FrostError {
     /// The FROST P2P inbound receiver was already taken.
     #[error("frost p2p inbound receiver already taken")]
     P2PInboundReceiverAlreadyTaken,
-    /// The FROST broadcast event receiver was already taken.
-    #[error("frost bcast event receiver already taken")]
-    BcastEventReceiverAlreadyTaken,
     /// The round-1 casts receiver was dropped before local self-delivery.
     #[error("frost round 1 casts receiver dropped before self-delivery")]
     Round1CastsReceiverDropped,

--- a/crates/dkg/src/frostp2p.rs
+++ b/crates/dkg/src/frostp2p.rs
@@ -58,13 +58,7 @@
 //!        |
 //!        v
 //!   FrostP2P::round1
-//!        |-----------------------> bcast::Component
-//!        |                              |
-//!        |                              v
-//!        |                       bcast::Behaviour
-//!        |                              |
-//!        |                              v
-//!        |                    FrostP2PHandle::handle_bcast_event
+//!        |-----------------------> bcast::Component::broadcast_and_wait
 //!        |
 //!        +-----------------------> FrostP2PSender
 //!                                       |
@@ -89,11 +83,9 @@
 //!   reliable broadcast through [`bcast::Component`].
 //!
 //! The outer DKG network behaviour must install both `bcast::Behaviour` and
-//! [`FrostP2PBehaviour`]. It must also forward FROST broadcast completion
-//! events emitted by `bcast::Behaviour` into
-//! [`FrostP2PHandle::handle_bcast_event`]. Without that event bridge,
-//! [`FrostP2P`] cannot observe broadcast completion and `round1`/`round2` will
-//! wait until cancellation.
+//! [`FrostP2PBehaviour`]. [`FrostP2P`] uses
+//! [`bcast::Component::broadcast_and_wait`] so each round observes reliable
+//! broadcast completion before continuing.
 //!
 //! FROST observation events are emitted through [`FrostP2PBehaviour`] as swarm
 //! events. Transport-level code forwards round and broadcast milestones back to
@@ -497,43 +489,15 @@ pub(crate) struct FrostP2PHandle {
     /// Receives `(sender_peer_id, message)` for inbound round-1 P2P messages.
     inbound_rx: Option<mpsc::UnboundedReceiver<(PeerId, FrostRound1P2p)>>,
     sender: FrostP2PSender,
-    bcast_event_tx: mpsc::UnboundedSender<bcast::Event>,
-    bcast_event_rx: Option<mpsc::UnboundedReceiver<bcast::Event>>,
 }
 
 impl FrostP2PHandle {
-    /// Forwards FROST bcast completion events into the round state machine.
-    ///
-    /// The outer DKG network behaviour should route only events for FROST
-    /// message IDs here. Events for other bcast users are ignored defensively,
-    /// since this handle cannot re-deliver them to their owner.
-    pub(crate) fn handle_bcast_event(&self, event: bcast::Event) -> Result<(), FrostError> {
-        let msg_id = match &event {
-            bcast::Event::BroadcastCompleted { msg_id }
-            | bcast::Event::BroadcastFailed { msg_id, .. } => msg_id.as_str(),
-        };
-        if !is_frost_bcast_msg_id(msg_id) {
-            debug!(msg_id, "ignoring non-FROST bcast event");
-            return Ok(());
-        }
-
-        self.bcast_event_tx
-            .send(event)
-            .map_err(|_| FrostError::ChannelClosed("frost bcast event channel"))
-    }
-
     fn take_inbound_rx(
         &mut self,
     ) -> Result<mpsc::UnboundedReceiver<(PeerId, FrostRound1P2p)>, FrostError> {
         self.inbound_rx
             .take()
             .ok_or(FrostError::P2PInboundReceiverAlreadyTaken)
-    }
-
-    fn take_bcast_event_rx(&mut self) -> Result<mpsc::UnboundedReceiver<bcast::Event>, FrostError> {
-        self.bcast_event_rx
-            .take()
-            .ok_or(FrostError::BcastEventReceiverAlreadyTaken)
     }
 }
 
@@ -567,7 +531,6 @@ impl FrostP2PBehaviour {
         let num_peers = peers.len();
         let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
-        let (bcast_event_tx, bcast_event_rx) = mpsc::unbounded_channel();
         let sender = FrostP2PSender::new(cmd_tx);
         (
             Self {
@@ -587,8 +550,6 @@ impl FrostP2PBehaviour {
             FrostP2PHandle {
                 inbound_rx: Some(inbound_rx),
                 sender,
-                bcast_event_tx,
-                bcast_event_rx: Some(bcast_event_rx),
             },
         )
     }
@@ -876,7 +837,6 @@ impl NetworkBehaviour for FrostP2PBehaviour {
 pub(crate) struct FrostP2P {
     bcast_comp: bcast::Component,
     frost_sender: FrostP2PSender,
-    bcast_event_rx: mpsc::UnboundedReceiver<bcast::Event>,
     round1_casts_tx: mpsc::UnboundedSender<FrostRound1Casts>,
     round1_casts_rx: mpsc::UnboundedReceiver<FrostRound1Casts>,
     round1_p2p_rx: mpsc::UnboundedReceiver<(PeerId, FrostRound1P2p)>,
@@ -890,9 +850,7 @@ pub(crate) struct FrostP2P {
 /// Creates a FROST P2P transport and registers its bcast callbacks.
 ///
 /// The `frost_handle` must come from the [`FrostP2PBehaviour`] installed in the
-/// same outer network behaviour that owns `bcast_comp`. The outer behaviour
-/// must keep using that handle to forward [`bcast::Event`] values through
-/// [`FrostP2PHandle::handle_bcast_event`].
+/// same outer network behaviour that owns `bcast_comp`.
 pub(crate) async fn new_frost_p2p(
     bcast_comp: bcast::Component,
     frost_handle: &mut FrostP2PHandle,
@@ -906,7 +864,6 @@ pub(crate) async fn new_frost_p2p(
     let (round1_casts_tx, round1_casts_rx) = mpsc::unbounded_channel();
     let (round2_casts_tx, round2_casts_rx) = mpsc::unbounded_channel();
     let round1_p2p_rx = frost_handle.take_inbound_rx()?;
-    let bcast_event_rx = frost_handle.take_bcast_event_rx()?;
 
     register_round1_bcast(
         &bcast_comp,
@@ -927,7 +884,6 @@ pub(crate) async fn new_frost_p2p(
     Ok(FrostP2P {
         bcast_comp,
         frost_sender: frost_handle.sender.clone(),
-        bcast_event_rx,
         round1_casts_tx,
         round1_casts_rx,
         round1_p2p_rx,
@@ -1159,10 +1115,7 @@ impl FTransport for FrostP2P {
         self.emit_event(FrostP2PEvent::RoundStarted { round: 1 });
         let casts_msg = build_round1_casts(&bcast);
         self.emit_event(FrostP2PEvent::BroadcastStarted { round: 1 });
-        self.bcast_comp
-            .broadcast(ROUND1_CAST_ID, &casts_msg)
-            .await?;
-        self.wait_for_bcast_completion(ROUND1_CAST_ID, cancellation)
+        self.broadcast_round(ROUND1_CAST_ID, &casts_msg, cancellation)
             .await?;
         if let Err(error) = self.round1_casts_tx.send(casts_msg) {
             error!(%error, "frost round 1 casts receiver dropped before self-delivery");
@@ -1220,10 +1173,7 @@ impl FTransport for FrostP2P {
         self.emit_event(FrostP2PEvent::RoundStarted { round: 2 });
         let casts_msg = build_round2_casts(&bcast);
         self.emit_event(FrostP2PEvent::BroadcastStarted { round: 2 });
-        self.bcast_comp
-            .broadcast(ROUND2_CAST_ID, &casts_msg)
-            .await?;
-        self.wait_for_bcast_completion(ROUND2_CAST_ID, cancellation)
+        self.broadcast_round(ROUND2_CAST_ID, &casts_msg, cancellation)
             .await?;
         if let Err(error) = self.round2_casts_tx.send(casts_msg) {
             error!(%error, "frost round 2 casts receiver dropped before self-delivery");
@@ -1258,36 +1208,35 @@ impl FrostP2P {
         self.frost_sender.emit_event(event);
     }
 
-    async fn wait_for_bcast_completion(
-        &mut self,
-        expected_msg_id: &'static str,
+    /// Broadcasts a FROST round message and waits for terminal bcast status.
+    async fn broadcast_round<M>(
+        &self,
+        msg_id: &'static str,
+        msg: &M,
         cancellation: &CancellationToken,
-    ) -> Result<(), FrostError> {
-        loop {
-            tokio::select! {
-                biased;
-                _ = cancellation.cancelled() => return Err(FrostError::Cancelled),
-                event = self.bcast_event_rx.recv() => {
-                    match event.ok_or(FrostError::ChannelClosed("frost bcast event channel"))? {
-                        bcast::Event::BroadcastCompleted { msg_id } if msg_id == expected_msg_id => {
-                            self.emit_event(FrostP2PEvent::BroadcastCompleted {
-                                round: round_for_msg_id(expected_msg_id),
-                            });
-                            return Ok(());
-                        }
-                        bcast::Event::BroadcastFailed { msg_id, error } if msg_id == expected_msg_id => {
-                            self.emit_event(FrostP2PEvent::BroadcastFailed {
-                                round: round_for_msg_id(expected_msg_id),
-                                error: error.to_string(),
-                            });
-                            return Err(error.into());
-                        }
-                        bcast::Event::BroadcastFailed { msg_id, error } => {
-                            warn!(msg_id, expected_msg_id, %error, "ignoring unrelated failed bcast event")
-                        }
-                        event => debug!(?event, expected_msg_id, "ignoring unrelated bcast event"),
-                    }
-                }
+    ) -> Result<(), FrostError>
+    where
+        M: prost::Message + prost::Name + Default + Clone + Send + Sync + 'static,
+    {
+        let result = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(FrostError::Cancelled),
+            result = self.bcast_comp.broadcast_and_wait(msg_id, msg) => result,
+        };
+
+        match result {
+            Ok(()) => {
+                self.emit_event(FrostP2PEvent::BroadcastCompleted {
+                    round: round_for_msg_id(msg_id),
+                });
+                Ok(())
+            }
+            Err(error) => {
+                self.emit_event(FrostP2PEvent::BroadcastFailed {
+                    round: round_for_msg_id(msg_id),
+                    error: error.to_string(),
+                });
+                Err(error.into())
             }
         }
     }
@@ -1324,10 +1273,6 @@ fn round_for_msg_id(msg_id: &'static str) -> u8 {
         ROUND2_CAST_ID => 2,
         _ => 0,
     }
-}
-
-fn is_frost_bcast_msg_id(msg_id: &str) -> bool {
-    matches!(msg_id, ROUND1_CAST_ID | ROUND2_CAST_ID)
 }
 
 fn validate_round1_p2p(
@@ -2205,93 +2150,6 @@ mod tests {
             SendCommand::CancelAll
         ));
         drop(send_command);
-    }
-
-    #[tokio::test]
-    async fn bcast_event_handler_forwards_event() {
-        let (handler, mut event_rx) = frost_p2p_handle_for_test();
-
-        handler
-            .handle_bcast_event(bcast::Event::BroadcastCompleted {
-                msg_id: "other".to_string(),
-            })
-            .unwrap();
-        assert!(event_rx.try_recv().is_err());
-
-        handler
-            .handle_bcast_event(bcast::Event::BroadcastCompleted {
-                msg_id: ROUND1_CAST_ID.to_string(),
-            })
-            .unwrap();
-
-        assert!(matches!(
-            event_rx.recv().await.unwrap(),
-            bcast::Event::BroadcastCompleted { msg_id } if msg_id == ROUND1_CAST_ID
-        ));
-    }
-
-    #[tokio::test]
-    async fn wait_for_bcast_completion_observes_failure() {
-        let (event_tx, event_rx) = mpsc::unbounded_channel();
-        let mut transport = frost_p2p_for_bcast_event_test(event_rx);
-
-        event_tx
-            .send(bcast::Event::BroadcastFailed {
-                msg_id: ROUND2_CAST_ID.to_string(),
-                error: bcast::Error::BehaviourClosed,
-            })
-            .unwrap();
-
-        assert!(matches!(
-            transport
-                .wait_for_bcast_completion(ROUND2_CAST_ID, &CancellationToken::new())
-                .await,
-            Err(FrostError::Bcast(bcast::Error::BehaviourClosed))
-        ));
-    }
-
-    fn frost_p2p_handle_for_test() -> (FrostP2PHandle, mpsc::UnboundedReceiver<bcast::Event>) {
-        let (_inbound_tx, inbound_rx) = mpsc::unbounded_channel();
-        let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
-        let (bcast_event_tx, bcast_event_rx) = mpsc::unbounded_channel();
-        (
-            FrostP2PHandle {
-                inbound_rx: Some(inbound_rx),
-                sender: FrostP2PSender::new(cmd_tx),
-                bcast_event_tx,
-                bcast_event_rx: None,
-            },
-            bcast_event_rx,
-        )
-    }
-
-    fn frost_p2p_for_bcast_event_test(
-        bcast_event_rx: mpsc::UnboundedReceiver<bcast::Event>,
-    ) -> FrostP2P {
-        let (round1_casts_tx, round1_casts_rx) = mpsc::unbounded_channel();
-        let (_round1_p2p_tx, round1_p2p_rx) = mpsc::unbounded_channel();
-        let (round2_casts_tx, round2_casts_rx) = mpsc::unbounded_channel();
-        let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
-        let (bcast_behaviour, bcast_comp) = bcast::Behaviour::new(
-            Vec::new(),
-            pluto_p2p::p2p_context::P2PContext::default(),
-            pluto_testutil::random::generate_insecure_k1_key(1),
-        );
-        drop(bcast_behaviour);
-
-        FrostP2P {
-            bcast_comp,
-            frost_sender: FrostP2PSender::new(cmd_tx),
-            bcast_event_rx,
-            round1_casts_tx,
-            round1_casts_rx,
-            round1_p2p_rx,
-            round2_casts_tx,
-            round2_casts_rx,
-            peers_by_share_idx: HashMap::new(),
-            local_share_idx: 1,
-            num_peers: 0,
-        }
     }
 
     fn assert_invalid_peer_index<T>(result: Result<T, bcast::Error>, expected: PeerId) {

--- a/crates/dkg/src/frostp2p_integ_test.rs
+++ b/crates/dkg/src/frostp2p_integ_test.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     bcast,
     frost::run_frost_parallel,
-    frostp2p::{FrostP2P, FrostP2PBehaviour, FrostP2PEvent, FrostP2PHandle, new_frost_p2p},
+    frostp2p::{FrostP2P, FrostP2PBehaviour, FrostP2PEvent, new_frost_p2p},
     share::Share,
 };
 
@@ -42,13 +42,13 @@ struct TestBehaviour {
 
 #[derive(Debug)]
 enum TestBehaviourEvent {
-    Bcast(bcast::Event),
+    Bcast,
     Frost(FrostP2PEvent),
 }
 
 impl From<bcast::Event> for TestBehaviourEvent {
-    fn from(event: bcast::Event) -> Self {
-        Self::Bcast(event)
+    fn from(_event: bcast::Event) -> Self {
+        Self::Bcast
     }
 }
 
@@ -60,7 +60,6 @@ impl From<FrostP2PEvent> for TestBehaviourEvent {
 
 struct LocalNode {
     transport: FrostP2P,
-    frost_handle: FrostP2PHandle,
     node: Node<TestBehaviour>,
 }
 
@@ -283,11 +282,7 @@ async fn build_local_nodes(
             move |builder, _keypair| builder.with_inner(behaviour),
         )?;
 
-        nodes.push(LocalNode {
-            transport,
-            frost_handle,
-            node,
-        });
+        nodes.push(LocalNode { transport, node });
     }
 
     Ok(nodes)
@@ -303,7 +298,6 @@ fn spawn_nodes(
 
     for (index, local) in nodes.into_iter().enumerate() {
         let transport = local.transport;
-        let frost_handle = local.frost_handle;
         let mut node = local.node;
         let conn_tx = conn_tx.clone();
         let listen_tx = listen_tx.clone();
@@ -329,11 +323,6 @@ fn spawn_nodes(
                             }
                             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                                 let _ = conn_tx.send((index, peer_id));
-                            }
-                            SwarmEvent::Behaviour(PlutoBehaviourEvent::Inner(
-                                TestBehaviourEvent::Bcast(event),
-                            )) => {
-                                frost_handle.handle_bcast_event(event)?;
                             }
                             SwarmEvent::Behaviour(PlutoBehaviourEvent::Inner(
                                 TestBehaviourEvent::Frost(event),

--- a/crates/dkg/src/nodesigs.rs
+++ b/crates/dkg/src/nodesigs.rs
@@ -99,8 +99,8 @@ impl NodeSigBcast {
 
     /// Exchanges K1 signatures over the lock hash with all peers.
     ///
-    /// Signs `lock_hash` with `key`, broadcasts the signature to all peers, and
-    /// polls until every peer's signature has been received and verified.
+    /// Signs `lock_hash` with `key`, waits for reliable-broadcast completion,
+    /// then polls until every peer's signature has been received and verified.
     /// Returns all collected signatures ordered by peer index.
     pub async fn exchange(
         self,
@@ -129,7 +129,10 @@ impl NodeSigBcast {
 
         tracing::debug!("Exchanging node signatures");
 
-        self.bcast.broadcast(NODE_SIG_MSG_ID, &bcast_data).await?;
+        tokio::select! {
+            () = token.cancelled() => return Err(Error::Cancelled),
+            result = self.bcast.broadcast_and_wait(NODE_SIG_MSG_ID, &bcast_data) => result?,
+        }
 
         {
             let mut sigs = self.sigs.lock().unwrap_or_else(|e| e.into_inner());
@@ -430,6 +433,53 @@ mod tests {
 
         let guard = sigs.lock().unwrap();
         assert_eq!(guard[1], Some(NONE_DATA.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn exchange_observes_bcast_failure() -> anyhow::Result<()> {
+        let (key0, peer0) = make_peer(0, 0);
+        let (_, peer1) = make_peer(1, 1);
+        let peer_ids = vec![peer0.id, peer1.id];
+        let p2p_context = P2PContext::new(peer_ids.clone());
+        let (behaviour, component) = Behaviour::new(peer_ids, p2p_context.clone(), key0.clone());
+        let nsig =
+            NodeSigBcast::new(vec![peer0, peer1], 0, component, CancellationToken::new()).await?;
+
+        let mut node = Node::new_server(
+            P2PConfig::default(),
+            key0.clone(),
+            NodeType::TCP,
+            false,
+            p2p_context,
+            None,
+            move |builder, _| builder.with_inner(behaviour),
+        )?;
+        let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+        let node_task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut stop_rx => break,
+                    _ = node.select_next_some() => {}
+                }
+            }
+        });
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(5),
+            nsig.exchange(Some(&key0), [42u8; 32], CancellationToken::new()),
+        )
+        .await
+        .context("exchange should observe bcast failure")?
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            Error::Broadcast(bcast::Error::BroadcastFailed(_))
+        ));
+
+        let _ = stop_tx.send(());
+        node_task.await?;
+
+        Ok(())
     }
 
     struct TestNode {

--- a/crates/dkg/src/nodesigs.rs
+++ b/crates/dkg/src/nodesigs.rs
@@ -436,7 +436,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exchange_observes_bcast_failure() -> anyhow::Result<()> {
+    async fn exchange_observes_bcast_failure_on_peer_unreachable() -> anyhow::Result<()> {
         let (key0, peer0) = make_peer(0, 0);
         let (_, peer1) = make_peer(1, 1);
         let peer_ids = vec![peer0.id, peer1.id];


### PR DESCRIPTION
This change makes DKG broadcast observable by callers that need completion.

Before, `bcast::Component::broadcast()` only enqueued work. Actual send success/failure arrived later as `bcast::Event`, but nodesigs and FROST flows had already moved on or were waiting elsewhere. That meant a failed broadcast could be dropped or ignored, causing DKG to hang until cancellation instead of failing with the real send error.

The fix adds `broadcast_and_wait()`: it enqueues the broadcast and waits for the behaviour’s terminal status. Nodesigs and FROST now use this API before continuing, so broadcast failures propagate immediately through their normal error paths. The old enqueue-only `broadcast()` remains for callers that consume events separately.