### PR TITLE
fix(dkg-runner): require bash with compgen builtin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,13 +26,12 @@
     {
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
+          bashInteractive
           cargo-deny
           cargo-llvm-cov
           cargo-machete
           protobuf
           oas3-gen
-
-          bashInteractive
         ];
 
         shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
           cargo-machete
           protobuf
           oas3-gen
+
+          bashInteractive
         ];
 
         shellHook = ''

--- a/scripts/dkg-runner/run.sh
+++ b/scripts/dkg-runner/run.sh
@@ -73,6 +73,11 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! type -t compgen >/dev/null 2>&1; then
+    log_err "compgen builtin is required (bash must be built with programmable completion)"
+    exit 1
+fi
+
 if is_truthy "${RUN_SMOKE_VERIFY}" && ! command -v curl >/dev/null 2>&1; then
     log_err "curl is required for runtime smoke verification"
     exit 1


### PR DESCRIPTION
The DKG runner scripts use the `compgen` bash builtin to discover generated keystores, but minimal bash builds (e.g. the default `bash` derivation in Nix) ship without it. Under `nix develop` the runner would then fail with a confusing error.

This PR:
- Adds `bashInteractive` to the dev shell so `compgen` is available.
- Fails fast in `run.sh` with a clear message when the builtin is missing.