### PR TITLE
chore: switch default relays to pluto-relay nethermind endpoints

### DIFF
--- a/crates/dkg/examples/bcast.rs
+++ b/crates/dkg/examples/bcast.rs
@@ -16,15 +16,15 @@
 //!
 //! # Run in 3 terminals against the generated node directories
 //! cargo run -p pluto-dkg --example bcast -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir /tmp/pluto-bcast-demo/node0
 //!
 //! cargo run -p pluto-dkg --example bcast -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir /tmp/pluto-bcast-demo/node1
 //!
 //! cargo run -p pluto-dkg --example bcast -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir /tmp/pluto-bcast-demo/node2
 //! ```
 //!

--- a/crates/dkg/examples/sync.rs
+++ b/crates/dkg/examples/sync.rs
@@ -16,15 +16,15 @@
 //!
 //! # Run in 3 terminals against the generated node directories
 //! cargo run -p pluto-dkg --example sync -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir /tmp/pluto-sync-demo/node0
 //!
 //! cargo run -p pluto-dkg --example sync -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir /tmp/pluto-sync-demo/node1
 //!
 //! cargo run -p pluto-dkg --example sync -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir /tmp/pluto-sync-demo/node2
 //! ```
 //!

--- a/crates/p2p/src/config.rs
+++ b/crates/p2p/src/config.rs
@@ -9,10 +9,9 @@ use std::{
 use libp2p::{Multiaddr, multiaddr, ping};
 
 /// Shared default relay endpoints used by commands and P2P-facing configs.
-pub const DEFAULT_RELAYS: [&str; 3] = [
-    "https://0.relay.obol.tech",
-    "https://2.relay.obol.dev",
-    "https://1.relay.obol.tech",
+pub const DEFAULT_RELAYS: [&str; 2] = [
+    "https://pluto-relay-0.ovh.dev-nethermind.xyz",
+    "https://pluto-relay-1.ovh.dev-nethermind.xyz",
 ];
 
 /// P2P configuration error.

--- a/crates/p2p/src/config.rs
+++ b/crates/p2p/src/config.rs
@@ -9,9 +9,12 @@ use std::{
 use libp2p::{Multiaddr, multiaddr, ping};
 
 /// Shared default relay endpoints used by commands and P2P-facing configs.
-pub const DEFAULT_RELAYS: [&str; 2] = [
+pub const DEFAULT_RELAYS: [&str; 5] = [
     "https://pluto-relay-0.ovh.dev-nethermind.xyz",
     "https://pluto-relay-1.ovh.dev-nethermind.xyz",
+    "https://0.relay.obol.tech",
+    "https://2.relay.obol.dev",
+    "https://1.relay.obol.tech",
 ];
 
 /// P2P configuration error.

--- a/crates/parsigex/examples/parsigex.rs
+++ b/crates/parsigex/examples/parsigex.rs
@@ -31,17 +31,17 @@
 //! ```bash
 //! # Terminal 1
 //! cargo run -p pluto-parsigex --example parsigex -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir ./cluster/node0 --share-idx 1
 //!
 //! # Terminal 2
 //! cargo run -p pluto-parsigex --example parsigex -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir ./cluster/node1 --share-idx 2
 //!
 //! # Terminal 3
 //! cargo run -p pluto-parsigex --example parsigex -- \
-//!   --relays https://0.relay.obol.tech,https://1.relay.obol.tech \
+//!   --relays https://pluto-relay-0.ovh.dev-nethermind.xyz,https://pluto-relay-1.ovh.dev-nethermind.xyz \
 //!   --data-dir ./cluster/node2 --share-idx 3
 //! ```
 //!

--- a/scripts/dkg-runner/README.md
+++ b/scripts/dkg-runner/README.md
@@ -6,7 +6,7 @@ Shell scripts for running a complete DKG ceremony with a configurable mix of Plu
 
 - Pluto binary built (used for `create dkg` and for any Pluto nodes in the ceremony): `cargo build -p pluto-cli`
 - `charon` binary on your `$PATH` and `curl` installed (required when `RUN_SMOKE_VERIFY` is enabled; this is the default)
-- Relay server reachable (default: `https://0.relay.obol.tech`)
+- Relay server reachable (default: `https://pluto-relay-0.ovh.dev-nethermind.xyz`)
 
 ## Quick start
 
@@ -30,7 +30,7 @@ NODES=4 THRESHOLD=3 PLUTO_NODES=1 CHARON_NODES=3 ./scripts/dkg-runner/run.sh
 
 # Release binary, custom relay, longer timeout
 PLUTO_BIN=./target/release/pluto \
-RELAY_URL=https://0.relay.obol.tech \
+RELAY_URL=https://pluto-relay-0.ovh.dev-nethermind.xyz \
 TIMEOUT=300 \
 ./scripts/dkg-runner/run.sh
 
@@ -55,7 +55,7 @@ All variables are optional. Set them in the environment before calling any scrip
 | `THRESHOLD` | `3` | Min shares required to reconstruct the key |
 | `PLUTO_NODES` | `2` | How many slots use the Pluto binary (fills slots 0…N-1) |
 | `CHARON_NODES` | `2` | How many slots use the Charon binary (fills remaining slots) |
-| `RELAY_URL` | `https://0.relay.obol.tech` | Relay ENR endpoint passed to the DKG nodes |
+| `RELAY_URL` | `https://pluto-relay-0.ovh.dev-nethermind.xyz` | Relay ENR endpoint passed to the DKG nodes |
 | `NETWORK` | `holesky` | Ethereum network for the cluster definition |
 | `FEE_RECIPIENT` | `0xDeaDBeef…` | Fee recipient address for the cluster |
 | `WITHDRAWAL_ADDR` | `0xDeaDBeef…` | Withdrawal address for the cluster |

--- a/scripts/dkg-runner/config.sh
+++ b/scripts/dkg-runner/config.sh
@@ -9,7 +9,7 @@
 : "${THRESHOLD:=3}"
 : "${PLUTO_NODES:=2}"
 : "${CHARON_NODES:=2}"
-: "${RELAY_URL:=https://0.relay.obol.tech}"
+: "${RELAY_URL:=https://pluto-relay-0.ovh.dev-nethermind.xyz}"
 : "${TIMEOUT:=120}"
 : "${SHUTDOWN_DELAY:=5s}"
 : "${NODE_EXIT_TIMEOUT:=90}"

--- a/scripts/dkg-runner/run-node.sh
+++ b/scripts/dkg-runner/run-node.sh
@@ -15,7 +15,7 @@
 #   PLUTO_BIN=./target/debug/pluto
 #   CHARON_BIN=charon
 #   WORK_DIR=/tmp/dkg-run
-#   RELAY_URL=https://0.relay.obol.tech
+#   RELAY_URL=https://pluto-relay-0.ovh.dev-nethermind.xyz
 
 set -euo pipefail
 

--- a/scripts/dkg-runner/run.sh
+++ b/scripts/dkg-runner/run.sh
@@ -9,7 +9,7 @@
 #   THRESHOLD=3          Signing threshold (min shares required to reconstruct).
 #   PLUTO_NODES=2        How many of the NODES slots use the Pluto binary.
 #   CHARON_NODES=2       How many of the NODES slots use the Charon binary.
-#   RELAY_URL=https://0.relay.obol.tech
+#   RELAY_URL=https://pluto-relay-0.ovh.dev-nethermind.xyz
 #                        Relay ENR endpoint used by the DKG nodes.
 #   TIMEOUT=120          Seconds to wait for all nodes before aborting.
 #   NODE_EXIT_TIMEOUT=90 Seconds to wait for nodes to exit after completion.

--- a/test-infra/docker-compose.mixed-dkg-test.yml
+++ b/test-infra/docker-compose.mixed-dkg-test.yml
@@ -10,7 +10,7 @@
 #
 # Use the external Obol relay instead of the internal one:
 #
-#   RELAY_URL=https://0.relay.obol.tech \
+#   RELAY_URL=https://pluto-relay-0.ovh.dev-nethermind.xyz \
 #     docker compose -f docker-compose.mixed-dkg-test.yml up
 #
 # Network topology — relay bridges isolated node networks; nodes share


### PR DESCRIPTION
## Summary
- Replaces the public Obol relays (`{0,1,2}.relay.obol.{tech,dev}`) with the new self-hosted endpoints `https://pluto-relay-{0,1}.ovh.dev-nethermind.xyz` across `DEFAULT_RELAYS`, example doc-comments, the mixed-DKG docker-compose, and the `dkg-runner` scripts.
- `DEFAULT_RELAYS` shrinks from 3 to 2 entries since only two endpoints are provisioned.

## Test plan
- [x] `cargo check --workspace`
- [ ] DKG smoke run against the new relays (`./scripts/dkg-runner/run.sh`)