### PR TITLE
fix(keystore): flush file before return

### DIFF
--- a/crates/eth2util/src/keystore/store.rs
+++ b/crates/eth2util/src/keystore/store.rs
@@ -230,6 +230,7 @@ async fn write_file(path: impl AsRef<Path>, data: &[u8], mode: u32) -> Result<()
         .open(path.as_ref())
         .await?;
     file.write_all(data).await?;
+    file.flush().await?;
 
     Ok(())
 }


### PR DESCRIPTION
https://docs.rs/tokio/latest/tokio/fs/struct.File.html

> A file will not be closed immediately when it goes out of scope if there are any IO operations that have not yet completed. To ensure that a file is closed immediately when it is dropped, you should call [flush](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.flush) before dropping it. Note that this does not ensure that the file has been fully written to disk; the operating system might keep the changes around in an in-memory buffer. See the [sync_all](https://docs.rs/tokio/latest/tokio/fs/struct.File.html#method.sync_all) method for telling the OS to write the data to disk.
