### PR TITLE
test: add p2p end-to-end tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5836,6 +5836,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "unsigned-varint 0.8.0",
  "url",
  "vise",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5836,7 +5836,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "unsigned-varint 0.8.0",
  "url",
  "vise",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -43,8 +43,6 @@ libp2p.workspace = true
 k256.workspace = true
 tokio.workspace = true
 futures.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -39,6 +39,12 @@ anyhow.workspace = true
 clap.workspace = true
 pluto-cluster.workspace = true
 hex.workspace = true
+libp2p.workspace = true
+k256.workspace = true
+tokio.workspace = true
+futures.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/p2p/tests/direct_tcp_connection.rs
+++ b/crates/p2p/tests/direct_tcp_connection.rs
@@ -1,0 +1,230 @@
+//! End-to-end test for two real Pluto nodes connecting directly over TCP.
+//!
+//! Unlike `dkg::frostp2p_integ_test` (which uses `Node::new_server` with a
+//! custom test behaviour), this drives the full *production* client stack built
+//! by [`Node::new`]: the composed [`PlutoBehaviour`] with its connection
+//! logger, gater, identify, ping, autonat and QUIC-upgrade sub-behaviours, plus
+//! the libp2p relay *client* behaviour as the inner behaviour.
+//!
+//! The test asserts that two nodes, given only a listen address, establish a
+//! bidirectional connection and actually run the identify and ping protocols
+//! over it — proving the real behaviour stack negotiates and stays live.
+//!
+//! [`PlutoBehaviour`]: pluto_p2p::behaviours::pluto::PlutoBehaviour
+
+use std::{fmt::Debug, time::Duration};
+
+use anyhow::{Context as _, ensure};
+use futures::StreamExt as _;
+use libp2p::{Multiaddr, PeerId, identify, ping, relay, swarm::SwarmEvent};
+use pluto_p2p::{
+    behaviours::pluto::PlutoBehaviourEvent,
+    config::P2PConfig,
+    p2p::{Node, NodeType},
+    p2p_context::P2PContext,
+    peer::peer_id_from_key,
+};
+use pluto_testutil::random::generate_insecure_k1_key;
+use tokio::time::timeout;
+use tracing_subscriber::EnvFilter;
+
+/// A client node whose inner behaviour is the libp2p relay client — the same
+/// shape `Node::new` produces in production.
+type ClientNode = Node<relay::client::Behaviour>;
+/// Swarm event type yielded by [`ClientNode`].
+type ClientEvent = SwarmEvent<PlutoBehaviourEvent<relay::client::Behaviour>>;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// What we expect to observe on a single node over the connection's lifetime.
+#[derive(Default)]
+struct Observed {
+    connected: bool,
+    identified: bool,
+    pinged: bool,
+}
+
+impl Observed {
+    fn complete(&self) -> bool {
+        self.connected && self.identified && self.pinged
+    }
+}
+
+/// Installs a test tracing subscriber. Defaults to `warn` so connection and
+/// listener errors surface even without `RUST_LOG`; set e.g.
+/// `RUST_LOG=libp2p=debug,pluto_p2p=debug` for full transport tracing.
+fn init_logs() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_test_writer()
+        .try_init();
+}
+
+/// Logs swarm events instead of silently dropping them: failures at `warn`, the
+/// rest at `trace`. Surfaces the real cause of a hang instead of a bare
+/// timeout.
+fn note_swarm_event<E: Debug>(event: &SwarmEvent<E>) {
+    use SwarmEvent::*;
+    match event {
+        OutgoingConnectionError { peer_id, error, .. } => {
+            tracing::warn!(?peer_id, %error, "outgoing connection error");
+        }
+        IncomingConnectionError { error, .. } => {
+            tracing::warn!(%error, "incoming connection error");
+        }
+        ListenerError { error, .. } => {
+            tracing::warn!(%error, "listener error");
+        }
+        ListenerClosed {
+            reason: Err(error), ..
+        } => {
+            tracing::warn!(%error, "listener closed with error");
+        }
+        _ => tracing::trace!(?event, "swarm event"),
+    }
+}
+
+/// Builds a production client node listening on nothing yet, tracking
+/// `known_peer` in its [`P2PContext`].
+fn build_client_node(key: k256::SecretKey, known_peer: PeerId) -> anyhow::Result<ClientNode> {
+    let p2p_context = P2PContext::new(vec![known_peer]);
+    let node = Node::new(
+        P2PConfig::default(),
+        key,
+        NodeType::TCP,
+        // Keep loopback addresses: the test connects over 127.0.0.1.
+        false,
+        p2p_context,
+        |builder, _keypair, relay_client| builder.with_inner(relay_client),
+    )
+    .context("build production client node")?;
+
+    Ok(node)
+}
+
+/// Drives `node` until it reports a `NewListenAddr`, returning that address.
+async fn first_listen_addr(node: &mut ClientNode) -> anyhow::Result<Multiaddr> {
+    let wait = async {
+        loop {
+            let event = node.select_next_some().await;
+            note_swarm_event(&event);
+            if let SwarmEvent::NewListenAddr { address, .. } = event {
+                return address;
+            }
+        }
+    };
+
+    let address = timeout(TEST_TIMEOUT, wait)
+        .await
+        .context("timed out waiting for a listen address")?;
+
+    Ok(address)
+}
+
+/// Folds a single swarm event into `observed`, checking the peer identity on
+/// connection.
+fn record_event(
+    event: ClientEvent,
+    expected_peer: &PeerId,
+    observed: &mut Observed,
+) -> anyhow::Result<()> {
+    note_swarm_event(&event);
+    match event {
+        SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+            ensure!(
+                peer_id == *expected_peer,
+                "connected to unexpected peer {peer_id}, wanted {expected_peer}",
+            );
+            observed.connected = true;
+        }
+        // Only a `Received` proves the peers actually exchanged identify
+        // payloads, not merely that we sent ours.
+        SwarmEvent::Behaviour(PlutoBehaviourEvent::Identify(identify::Event::Received {
+            peer_id,
+            ..
+        })) => {
+            ensure!(
+                peer_id == *expected_peer,
+                "identify from unexpected peer {peer_id}, wanted {expected_peer}",
+            );
+            observed.identified = true;
+        }
+        SwarmEvent::Behaviour(PlutoBehaviourEvent::Ping(ping::Event { peer, result, .. })) => {
+            ensure!(
+                peer == *expected_peer,
+                "ping involving unexpected peer {peer}, wanted {expected_peer}",
+            );
+            // A measured RTT means the ping round-trip actually completed.
+            if result.is_ok() {
+                observed.pinged = true;
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_nodes_connect_identify_and_ping_over_tcp() -> anyhow::Result<()> {
+    init_logs();
+
+    let key_a = generate_insecure_k1_key(1);
+    let key_b = generate_insecure_k1_key(2);
+
+    let peer_a = peer_id_from_key(key_a.public_key()).context("derive peer id A")?;
+    let peer_b = peer_id_from_key(key_b.public_key()).context("derive peer id B")?;
+    ensure!(peer_a != peer_b, "test keys must yield distinct peer ids");
+
+    let mut node_a = build_client_node(key_a, peer_b)?;
+    let mut node_b = build_client_node(key_b, peer_a)?;
+
+    ensure!(
+        node_a.local_peer_id() == &peer_a,
+        "node A reported an unexpected local peer id",
+    );
+    ensure!(
+        node_b.local_peer_id() == &peer_b,
+        "node B reported an unexpected local peer id",
+    );
+
+    // Node A listens; node B dials the resulting address.
+    let listen = "/ip4/127.0.0.1/tcp/0"
+        .parse::<Multiaddr>()
+        .context("parse loopback listen multiaddr")?;
+    node_a.listen_on(listen).context("node A listen_on")?;
+
+    let dial_target = first_listen_addr(&mut node_a).await?;
+    node_b.dial(dial_target).context("node B dial node A")?;
+
+    // Drive both nodes until each has connected, exchanged identify, and
+    // completed a ping with the other.
+    let mut observed_a = Observed::default();
+    let mut observed_b = Observed::default();
+
+    let drive = async {
+        loop {
+            tokio::select! {
+                event = node_a.select_next_some() => {
+                    record_event(event, &peer_b, &mut observed_a)?;
+                }
+                event = node_b.select_next_some() => {
+                    record_event(event, &peer_a, &mut observed_b)?;
+                }
+            }
+
+            if observed_a.complete() && observed_b.complete() {
+                break;
+            }
+        }
+
+        anyhow::Ok(())
+    };
+
+    timeout(TEST_TIMEOUT, drive)
+        .await
+        .context("timed out before both nodes connected, identified and pinged")??;
+
+    Ok(())
+}

--- a/crates/p2p/tests/direct_tcp_connection.rs
+++ b/crates/p2p/tests/direct_tcp_connection.rs
@@ -12,9 +12,8 @@
 //!
 //! [`PlutoBehaviour`]: pluto_p2p::behaviours::pluto::PlutoBehaviour
 
-use std::{fmt::Debug, time::Duration};
+use std::time::Duration;
 
-use anyhow::{Context as _, ensure};
 use futures::StreamExt as _;
 use libp2p::{Multiaddr, PeerId, identify, ping, relay, swarm::SwarmEvent};
 use pluto_p2p::{
@@ -26,7 +25,6 @@ use pluto_p2p::{
 };
 use pluto_testutil::random::generate_insecure_k1_key;
 use tokio::time::timeout;
-use tracing_subscriber::EnvFilter;
 
 /// A client node whose inner behaviour is the libp2p relay client — the same
 /// shape `Node::new` produces in production.
@@ -50,46 +48,11 @@ impl Observed {
     }
 }
 
-/// Installs a test tracing subscriber. Defaults to `warn` so connection and
-/// listener errors surface even without `RUST_LOG`; set e.g.
-/// `RUST_LOG=libp2p=debug,pluto_p2p=debug` for full transport tracing.
-fn init_logs() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_test_writer()
-        .try_init();
-}
-
-/// Logs swarm events instead of silently dropping them: failures at `warn`, the
-/// rest at `trace`. Surfaces the real cause of a hang instead of a bare
-/// timeout.
-fn note_swarm_event<E: Debug>(event: &SwarmEvent<E>) {
-    use SwarmEvent::*;
-    match event {
-        OutgoingConnectionError { peer_id, error, .. } => {
-            tracing::warn!(?peer_id, %error, "outgoing connection error");
-        }
-        IncomingConnectionError { error, .. } => {
-            tracing::warn!(%error, "incoming connection error");
-        }
-        ListenerError { error, .. } => {
-            tracing::warn!(%error, "listener error");
-        }
-        ListenerClosed {
-            reason: Err(error), ..
-        } => {
-            tracing::warn!(%error, "listener closed with error");
-        }
-        _ => tracing::trace!(?event, "swarm event"),
-    }
-}
-
 /// Builds a production client node listening on nothing yet, tracking
 /// `known_peer` in its [`P2PContext`].
-fn build_client_node(key: k256::SecretKey, known_peer: PeerId) -> anyhow::Result<ClientNode> {
+fn build_client_node(key: k256::SecretKey, known_peer: PeerId) -> ClientNode {
     let p2p_context = P2PContext::new(vec![known_peer]);
-    let node = Node::new(
+    Node::new(
         P2PConfig::default(),
         key,
         NodeType::TCP,
@@ -98,41 +61,31 @@ fn build_client_node(key: k256::SecretKey, known_peer: PeerId) -> anyhow::Result
         p2p_context,
         |builder, _keypair, relay_client| builder.with_inner(relay_client),
     )
-    .context("build production client node")?;
-
-    Ok(node)
+    .expect("build production client node")
 }
 
 /// Drives `node` until it reports a `NewListenAddr`, returning that address.
-async fn first_listen_addr(node: &mut ClientNode) -> anyhow::Result<Multiaddr> {
+async fn first_listen_addr(node: &mut ClientNode) -> Multiaddr {
     let wait = async {
         loop {
             let event = node.select_next_some().await;
-            note_swarm_event(&event);
             if let SwarmEvent::NewListenAddr { address, .. } = event {
                 return address;
             }
         }
     };
 
-    let address = timeout(TEST_TIMEOUT, wait)
+    timeout(TEST_TIMEOUT, wait)
         .await
-        .context("timed out waiting for a listen address")?;
-
-    Ok(address)
+        .expect("timed out waiting for a listen address")
 }
 
 /// Folds a single swarm event into `observed`, checking the peer identity on
 /// connection.
-fn record_event(
-    event: ClientEvent,
-    expected_peer: &PeerId,
-    observed: &mut Observed,
-) -> anyhow::Result<()> {
-    note_swarm_event(&event);
+fn record_event(event: ClientEvent, expected_peer: &PeerId, observed: &mut Observed) {
     match event {
         SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-            ensure!(
+            assert!(
                 peer_id == *expected_peer,
                 "connected to unexpected peer {peer_id}, wanted {expected_peer}",
             );
@@ -144,14 +97,14 @@ fn record_event(
             peer_id,
             ..
         })) => {
-            ensure!(
+            assert!(
                 peer_id == *expected_peer,
                 "identify from unexpected peer {peer_id}, wanted {expected_peer}",
             );
             observed.identified = true;
         }
         SwarmEvent::Behaviour(PlutoBehaviourEvent::Ping(ping::Event { peer, result, .. })) => {
-            ensure!(
+            assert!(
                 peer == *expected_peer,
                 "ping involving unexpected peer {peer}, wanted {expected_peer}",
             );
@@ -162,29 +115,25 @@ fn record_event(
         }
         _ => {}
     }
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn two_nodes_connect_identify_and_ping_over_tcp() -> anyhow::Result<()> {
-    init_logs();
-
+async fn two_nodes_connect_identify_and_ping_over_tcp() {
     let key_a = generate_insecure_k1_key(1);
     let key_b = generate_insecure_k1_key(2);
 
-    let peer_a = peer_id_from_key(key_a.public_key()).context("derive peer id A")?;
-    let peer_b = peer_id_from_key(key_b.public_key()).context("derive peer id B")?;
-    ensure!(peer_a != peer_b, "test keys must yield distinct peer ids");
+    let peer_a = peer_id_from_key(key_a.public_key()).expect("derive peer id A");
+    let peer_b = peer_id_from_key(key_b.public_key()).expect("derive peer id B");
+    assert!(peer_a != peer_b, "test keys must yield distinct peer ids");
 
-    let mut node_a = build_client_node(key_a, peer_b)?;
-    let mut node_b = build_client_node(key_b, peer_a)?;
+    let mut node_a = build_client_node(key_a, peer_b);
+    let mut node_b = build_client_node(key_b, peer_a);
 
-    ensure!(
+    assert!(
         node_a.local_peer_id() == &peer_a,
         "node A reported an unexpected local peer id",
     );
-    ensure!(
+    assert!(
         node_b.local_peer_id() == &peer_b,
         "node B reported an unexpected local peer id",
     );
@@ -192,11 +141,11 @@ async fn two_nodes_connect_identify_and_ping_over_tcp() -> anyhow::Result<()> {
     // Node A listens; node B dials the resulting address.
     let listen = "/ip4/127.0.0.1/tcp/0"
         .parse::<Multiaddr>()
-        .context("parse loopback listen multiaddr")?;
-    node_a.listen_on(listen).context("node A listen_on")?;
+        .expect("parse loopback listen multiaddr");
+    node_a.listen_on(listen).expect("node A listen_on");
 
-    let dial_target = first_listen_addr(&mut node_a).await?;
-    node_b.dial(dial_target).context("node B dial node A")?;
+    let dial_target = first_listen_addr(&mut node_a).await;
+    node_b.dial(dial_target).expect("node B dial node A");
 
     // Drive both nodes until each has connected, exchanged identify, and
     // completed a ping with the other.
@@ -207,10 +156,10 @@ async fn two_nodes_connect_identify_and_ping_over_tcp() -> anyhow::Result<()> {
         loop {
             tokio::select! {
                 event = node_a.select_next_some() => {
-                    record_event(event, &peer_b, &mut observed_a)?;
+                    record_event(event, &peer_b, &mut observed_a);
                 }
                 event = node_b.select_next_some() => {
-                    record_event(event, &peer_a, &mut observed_b)?;
+                    record_event(event, &peer_a, &mut observed_b);
                 }
             }
 
@@ -218,13 +167,9 @@ async fn two_nodes_connect_identify_and_ping_over_tcp() -> anyhow::Result<()> {
                 break;
             }
         }
-
-        anyhow::Ok(())
     };
 
     timeout(TEST_TIMEOUT, drive)
         .await
-        .context("timed out before both nodes connected, identified and pinged")??;
-
-    Ok(())
+        .expect("timed out before both nodes connected, identified and pinged");
 }

--- a/crates/p2p/tests/relay_circuit.rs
+++ b/crates/p2p/tests/relay_circuit.rs
@@ -16,7 +16,6 @@
 
 use std::{fmt::Debug, time::Duration};
 
-use anyhow::{Context as _, ensure};
 use futures::StreamExt as _;
 use libp2p::{Multiaddr, PeerId, multiaddr::Protocol, relay, swarm::SwarmEvent};
 use pluto_p2p::{
@@ -73,16 +72,16 @@ fn note_swarm_event<E: Debug>(label: &str, event: &SwarmEvent<E>) {
 }
 
 #[tokio::test]
-async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
+async fn two_nodes_connect_through_relay_circuit() {
     init_logs();
 
     let relay_key = generate_insecure_k1_key(1);
     let listener_key = generate_insecure_k1_key(2);
     let dialer_key = generate_insecure_k1_key(3);
 
-    let relay_peer = peer_id_from_key(relay_key.public_key()).context("relay peer id")?;
-    let listener_peer = peer_id_from_key(listener_key.public_key()).context("listener peer id")?;
-    let dialer_peer = peer_id_from_key(dialer_key.public_key()).context("dialer peer id")?;
+    let relay_peer = peer_id_from_key(relay_key.public_key()).expect("relay peer id");
+    let listener_peer = peer_id_from_key(listener_key.public_key()).expect("listener peer id");
+    let dialer_peer = peer_id_from_key(dialer_key.public_key()).expect("dialer peer id");
 
     // --- Relay server node. ---
     let relay_config = relay::Config {
@@ -108,14 +107,14 @@ async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
             builder.with_inner(behaviour)
         },
     )
-    .context("build relay server node")?;
+    .expect("build relay server node");
 
     let relay_listen = "/ip4/127.0.0.1/tcp/0"
         .parse::<Multiaddr>()
-        .context("parse relay listen multiaddr")?;
+        .expect("parse relay listen multiaddr");
     relay_node
         .listen_on(relay_listen)
-        .context("relay listen_on")?;
+        .expect("relay listen_on");
 
     // Wait for the relay's concrete TCP address, then keep the relay driven in
     // the background so it can service reservations and circuits.
@@ -129,7 +128,7 @@ async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
         }
     })
     .await
-    .context("timed out waiting for the relay listen address")?;
+    .expect("timed out waiting for the relay listen address");
 
     // The relay must advertise a reachable address, otherwise reservations are
     // rejected client-side with `NoAddressesInReservation`.
@@ -147,8 +146,8 @@ async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
     let circuit_base = relay_with_id.clone().with(Protocol::P2pCircuit);
 
     // --- Two client nodes. ---
-    let make_client = |key, known: PeerId| -> anyhow::Result<Node<relay::client::Behaviour>> {
-        let node = Node::new(
+    let make_client = |key, known: PeerId| -> Node<relay::client::Behaviour> {
+        Node::new(
             P2PConfig::default(),
             key,
             NodeType::TCP,
@@ -156,18 +155,16 @@ async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
             P2PContext::new(vec![known, relay_peer]),
             |builder, _keypair, relay_client| builder.with_inner(relay_client),
         )
-        .context("build relay client node")?;
-
-        Ok(node)
+        .expect("build relay client node")
     };
 
-    let mut listener = make_client(listener_key, dialer_peer)?;
-    let mut dialer = make_client(dialer_key, listener_peer)?;
+    let mut listener = make_client(listener_key, dialer_peer);
+    let mut dialer = make_client(dialer_key, listener_peer);
 
     // The listener reserves a relay slot by listening on the circuit address.
     listener
         .listen_on(circuit_base.clone())
-        .context("listener listen_on circuit")?;
+        .expect("listener listen_on circuit");
 
     // Drive the listener until the reservation is confirmed (a relayed listen
     // address appears).
@@ -182,13 +179,13 @@ async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
         }
     })
     .await
-    .context("timed out waiting for the listener's relay reservation")?;
+    .expect("timed out waiting for the listener's relay reservation");
 
     // The dialer reaches the listener purely through the relay circuit.
     let dial_target = circuit_base.with(Protocol::P2p(listener_peer));
     dialer
         .dial(dial_target)
-        .context("dialer dial listener via circuit")?;
+        .expect("dialer dial listener via circuit");
 
     // Both ends must observe a connection to *each other* (connections to the
     // relay peer don't count).
@@ -218,18 +215,16 @@ async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
         }
     })
     .await
-    .context("timed out establishing the relayed connection")?;
+    .expect("timed out establishing the relayed connection");
 
-    ensure!(
+    assert!(
         listener_linked,
         "listener never saw the dialer over the relay"
     );
-    ensure!(
+    assert!(
         dialer_linked,
         "dialer never reached the listener over the relay"
     );
 
     relay_handle.abort();
-
-    Ok(())
 }

--- a/crates/p2p/tests/relay_circuit.rs
+++ b/crates/p2p/tests/relay_circuit.rs
@@ -23,18 +23,13 @@ use pluto_p2p::{
     p2p::{Node, NodeType},
     p2p_context::P2PContext,
     peer::peer_id_from_key,
+    utils::is_relay_addr,
 };
 use pluto_testutil::random::generate_insecure_k1_key;
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Returns true if `addr` is a relayed (`/p2p-circuit`) address.
-fn is_circuit_addr(addr: &Multiaddr) -> bool {
-    addr.iter()
-        .any(|proto| matches!(proto, Protocol::P2pCircuit))
-}
 
 /// Installs a test tracing subscriber. Defaults to `warn` so reservation and
 /// circuit failures surface even without `RUST_LOG`; set e.g.
@@ -172,7 +167,7 @@ async fn two_nodes_connect_through_relay_circuit() {
         loop {
             let event = listener.select_next_some().await;
             note_swarm_event("listener", &event);
-            if matches!(event, SwarmEvent::NewListenAddr { ref address, .. } if is_circuit_addr(address))
+            if matches!(event, SwarmEvent::NewListenAddr { ref address, .. } if is_relay_addr(address))
             {
                 return;
             }

--- a/crates/p2p/tests/relay_circuit.rs
+++ b/crates/p2p/tests/relay_circuit.rs
@@ -1,0 +1,235 @@
+//! End-to-end test for relayed connectivity through an in-process relay.
+//!
+//! Two Pluto client nodes that never dial each other directly instead connect
+//! through a third Pluto node running the libp2p relay *server* behaviour:
+//!
+//! 1. the relay node ([`Node::new_server`] + [`relay::Behaviour`]) listens on
+//!    loopback TCP;
+//! 2. a *listener* client ([`Node::new`], relay client inner) reserves a slot
+//!    on the relay by listening on the relay's `/p2p-circuit` address;
+//! 3. a *dialer* client dials the listener through that circuit address and the
+//!    two establish a relayed connection.
+//!
+//! This exercises the production [`Node`] plumbing for both the relay server
+//! and relay client paths over real sockets — the relay reservation and circuit
+//! hop, not just a direct dial.
+
+use std::{fmt::Debug, time::Duration};
+
+use anyhow::{Context as _, ensure};
+use futures::StreamExt as _;
+use libp2p::{Multiaddr, PeerId, multiaddr::Protocol, relay, swarm::SwarmEvent};
+use pluto_p2p::{
+    config::P2PConfig,
+    p2p::{Node, NodeType},
+    p2p_context::P2PContext,
+    peer::peer_id_from_key,
+};
+use pluto_testutil::random::generate_insecure_k1_key;
+use tokio::time::timeout;
+use tracing_subscriber::EnvFilter;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Returns true if `addr` is a relayed (`/p2p-circuit`) address.
+fn is_circuit_addr(addr: &Multiaddr) -> bool {
+    addr.iter()
+        .any(|proto| matches!(proto, Protocol::P2pCircuit))
+}
+
+/// Installs a test tracing subscriber. Defaults to `warn` so reservation and
+/// circuit failures surface even without `RUST_LOG`; set e.g.
+/// `RUST_LOG=libp2p=debug,pluto_p2p=debug` for full transport tracing.
+fn init_logs() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_test_writer()
+        .try_init();
+}
+
+/// Logs swarm events instead of silently dropping them: failures at `warn`, the
+/// rest at `trace`. A rejected reservation or failed circuit dial then shows up
+/// in the logs rather than as a bare timeout.
+fn note_swarm_event<E: Debug>(label: &str, event: &SwarmEvent<E>) {
+    use SwarmEvent::*;
+    match event {
+        OutgoingConnectionError { peer_id, error, .. } => {
+            tracing::warn!(node = label, ?peer_id, %error, "outgoing connection error");
+        }
+        IncomingConnectionError { error, .. } => {
+            tracing::warn!(node = label, %error, "incoming connection error");
+        }
+        ListenerError { error, .. } => {
+            tracing::warn!(node = label, %error, "listener error");
+        }
+        ListenerClosed {
+            reason: Err(error), ..
+        } => {
+            tracing::warn!(node = label, %error, "listener closed with error");
+        }
+        _ => tracing::trace!(node = label, ?event, "swarm event"),
+    }
+}
+
+#[tokio::test]
+async fn two_nodes_connect_through_relay_circuit() -> anyhow::Result<()> {
+    init_logs();
+
+    let relay_key = generate_insecure_k1_key(1);
+    let listener_key = generate_insecure_k1_key(2);
+    let dialer_key = generate_insecure_k1_key(3);
+
+    let relay_peer = peer_id_from_key(relay_key.public_key()).context("relay peer id")?;
+    let listener_peer = peer_id_from_key(listener_key.public_key()).context("listener peer id")?;
+    let dialer_peer = peer_id_from_key(dialer_key.public_key()).context("dialer peer id")?;
+
+    // --- Relay server node. ---
+    let relay_config = relay::Config {
+        max_reservations: 16,
+        max_reservations_per_peer: 4,
+        reservation_duration: Duration::from_secs(3600),
+        reservation_rate_limiters: vec![],
+        max_circuits: 16,
+        max_circuits_per_peer: 4,
+        max_circuit_duration: Duration::from_secs(120),
+        max_circuit_bytes: 32 * 1024 * 1024,
+        circuit_src_rate_limiters: vec![],
+    };
+    let mut relay_node = Node::new_server(
+        P2PConfig::default(),
+        relay_key,
+        NodeType::TCP,
+        false,
+        P2PContext::default(),
+        None,
+        move |builder, keypair| {
+            let behaviour = relay::Behaviour::new(keypair.public().to_peer_id(), relay_config);
+            builder.with_inner(behaviour)
+        },
+    )
+    .context("build relay server node")?;
+
+    let relay_listen = "/ip4/127.0.0.1/tcp/0"
+        .parse::<Multiaddr>()
+        .context("parse relay listen multiaddr")?;
+    relay_node
+        .listen_on(relay_listen)
+        .context("relay listen_on")?;
+
+    // Wait for the relay's concrete TCP address, then keep the relay driven in
+    // the background so it can service reservations and circuits.
+    let relay_addr = timeout(TEST_TIMEOUT, async {
+        loop {
+            let event = relay_node.select_next_some().await;
+            note_swarm_event("relay", &event);
+            if let SwarmEvent::NewListenAddr { address, .. } = event {
+                return address;
+            }
+        }
+    })
+    .await
+    .context("timed out waiting for the relay listen address")?;
+
+    // The relay must advertise a reachable address, otherwise reservations are
+    // rejected client-side with `NoAddressesInReservation`.
+    relay_node.add_external_address(relay_addr.clone());
+
+    let relay_handle = tokio::spawn(async move {
+        loop {
+            let event = relay_node.select_next_some().await;
+            note_swarm_event("relay", &event);
+        }
+    });
+
+    // Full relay address including its peer id, plus the circuit suffix.
+    let relay_with_id = relay_addr.with(Protocol::P2p(relay_peer));
+    let circuit_base = relay_with_id.clone().with(Protocol::P2pCircuit);
+
+    // --- Two client nodes. ---
+    let make_client = |key, known: PeerId| -> anyhow::Result<Node<relay::client::Behaviour>> {
+        let node = Node::new(
+            P2PConfig::default(),
+            key,
+            NodeType::TCP,
+            false,
+            P2PContext::new(vec![known, relay_peer]),
+            |builder, _keypair, relay_client| builder.with_inner(relay_client),
+        )
+        .context("build relay client node")?;
+
+        Ok(node)
+    };
+
+    let mut listener = make_client(listener_key, dialer_peer)?;
+    let mut dialer = make_client(dialer_key, listener_peer)?;
+
+    // The listener reserves a relay slot by listening on the circuit address.
+    listener
+        .listen_on(circuit_base.clone())
+        .context("listener listen_on circuit")?;
+
+    // Drive the listener until the reservation is confirmed (a relayed listen
+    // address appears).
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            let event = listener.select_next_some().await;
+            note_swarm_event("listener", &event);
+            if matches!(event, SwarmEvent::NewListenAddr { ref address, .. } if is_circuit_addr(address))
+            {
+                return;
+            }
+        }
+    })
+    .await
+    .context("timed out waiting for the listener's relay reservation")?;
+
+    // The dialer reaches the listener purely through the relay circuit.
+    let dial_target = circuit_base.with(Protocol::P2p(listener_peer));
+    dialer
+        .dial(dial_target)
+        .context("dialer dial listener via circuit")?;
+
+    // Both ends must observe a connection to *each other* (connections to the
+    // relay peer don't count).
+    let mut listener_linked = false;
+    let mut dialer_linked = false;
+
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            tokio::select! {
+                event = listener.select_next_some() => {
+                    note_swarm_event("listener", &event);
+                    if matches!(event, SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == dialer_peer) {
+                        listener_linked = true;
+                    }
+                }
+                event = dialer.select_next_some() => {
+                    note_swarm_event("dialer", &event);
+                    if matches!(event, SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == listener_peer) {
+                        dialer_linked = true;
+                    }
+                }
+            }
+
+            if listener_linked && dialer_linked {
+                break;
+            }
+        }
+    })
+    .await
+    .context("timed out establishing the relayed connection")?;
+
+    ensure!(
+        listener_linked,
+        "listener never saw the dialer over the relay"
+    );
+    ensure!(
+        dialer_linked,
+        "dialer never reached the listener over the relay"
+    );
+
+    relay_handle.abort();
+
+    Ok(())
+}

--- a/crates/p2p/tests/relay_circuit.rs
+++ b/crates/p2p/tests/relay_circuit.rs
@@ -69,9 +69,7 @@ async fn two_nodes_connect_through_relay_circuit() {
     let relay_listen = "/ip4/127.0.0.1/tcp/0"
         .parse::<Multiaddr>()
         .expect("parse relay listen multiaddr");
-    relay_node
-        .listen_on(relay_listen)
-        .expect("relay listen_on");
+    relay_node.listen_on(relay_listen).expect("relay listen_on");
 
     // Wait for the relay's concrete TCP address, then keep the relay driven in
     // the background so it can service reservations and circuits.

--- a/crates/p2p/tests/relay_circuit.rs
+++ b/crates/p2p/tests/relay_circuit.rs
@@ -14,7 +14,7 @@
 //! and relay client paths over real sockets — the relay reservation and circuit
 //! hop, not just a direct dial.
 
-use std::{fmt::Debug, time::Duration};
+use std::time::Duration;
 
 use futures::StreamExt as _;
 use libp2p::{Multiaddr, PeerId, multiaddr::Protocol, relay, swarm::SwarmEvent};
@@ -27,49 +27,11 @@ use pluto_p2p::{
 };
 use pluto_testutil::random::generate_insecure_k1_key;
 use tokio::time::timeout;
-use tracing_subscriber::EnvFilter;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Installs a test tracing subscriber. Defaults to `warn` so reservation and
-/// circuit failures surface even without `RUST_LOG`; set e.g.
-/// `RUST_LOG=libp2p=debug,pluto_p2p=debug` for full transport tracing.
-fn init_logs() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_test_writer()
-        .try_init();
-}
-
-/// Logs swarm events instead of silently dropping them: failures at `warn`, the
-/// rest at `trace`. A rejected reservation or failed circuit dial then shows up
-/// in the logs rather than as a bare timeout.
-fn note_swarm_event<E: Debug>(label: &str, event: &SwarmEvent<E>) {
-    use SwarmEvent::*;
-    match event {
-        OutgoingConnectionError { peer_id, error, .. } => {
-            tracing::warn!(node = label, ?peer_id, %error, "outgoing connection error");
-        }
-        IncomingConnectionError { error, .. } => {
-            tracing::warn!(node = label, %error, "incoming connection error");
-        }
-        ListenerError { error, .. } => {
-            tracing::warn!(node = label, %error, "listener error");
-        }
-        ListenerClosed {
-            reason: Err(error), ..
-        } => {
-            tracing::warn!(node = label, %error, "listener closed with error");
-        }
-        _ => tracing::trace!(node = label, ?event, "swarm event"),
-    }
-}
-
 #[tokio::test]
 async fn two_nodes_connect_through_relay_circuit() {
-    init_logs();
-
     let relay_key = generate_insecure_k1_key(1);
     let listener_key = generate_insecure_k1_key(2);
     let dialer_key = generate_insecure_k1_key(3);
@@ -116,7 +78,6 @@ async fn two_nodes_connect_through_relay_circuit() {
     let relay_addr = timeout(TEST_TIMEOUT, async {
         loop {
             let event = relay_node.select_next_some().await;
-            note_swarm_event("relay", &event);
             if let SwarmEvent::NewListenAddr { address, .. } = event {
                 return address;
             }
@@ -131,8 +92,7 @@ async fn two_nodes_connect_through_relay_circuit() {
 
     let relay_handle = tokio::spawn(async move {
         loop {
-            let event = relay_node.select_next_some().await;
-            note_swarm_event("relay", &event);
+            relay_node.select_next_some().await;
         }
     });
 
@@ -166,7 +126,6 @@ async fn two_nodes_connect_through_relay_circuit() {
     timeout(TEST_TIMEOUT, async {
         loop {
             let event = listener.select_next_some().await;
-            note_swarm_event("listener", &event);
             if matches!(event, SwarmEvent::NewListenAddr { ref address, .. } if is_relay_addr(address))
             {
                 return;
@@ -191,13 +150,11 @@ async fn two_nodes_connect_through_relay_circuit() {
         loop {
             tokio::select! {
                 event = listener.select_next_some() => {
-                    note_swarm_event("listener", &event);
                     if matches!(event, SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == dialer_peer) {
                         listener_linked = true;
                     }
                 }
                 event = dialer.select_next_some() => {
-                    note_swarm_event("dialer", &event);
                     if matches!(event, SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == listener_peer) {
                         dialer_linked = true;
                     }


### PR DESCRIPTION
The networking layer had almost no automated coverage. The existing `frostp2p_integ_test` uses a different path (`Node::new_server` + custom behaviour for FROST); the normal client path and the relay circuit hop were untested.

Two real-socket integration tests for the p2p layer:

- **`direct_tcp_connection.rs`** — two real Pluto nodes connect directly over TCP and run the full production `PlutoBehaviour`: connect both ways, exchange `identify` (`Received`), and `ping`.
- **`relay_circuit.rs`** — two clients connect *only* through an in-process relay (reservation + relayed dial), never directly.

Both log swarm errors at `warn` instead of swallowing them, so failures show the real cause, not a bare timeout.
