### PR TITLE
test(core): add Charon-parity fixture-replay harness for validatorapi

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,5 +62,9 @@ tower = { workspace = true, features = ["util"] }
 pluto-build-proto.workspace = true
 built.workspace = true
 
+[[test]]
+name = "charon_parity"
+path = "tests/charon_parity/main.rs"
+
 [lints]
 workspace = true

--- a/crates/core/testdata/charon-parity/README.md
+++ b/crates/core/testdata/charon-parity/README.md
@@ -1,0 +1,111 @@
+# Charon-parity fixture-replay harness
+
+Each JSON file in this directory drives one scenario through Pluto's
+`validatorapi::Handler` trait and asserts the outcome matches the
+behaviour established by Charon's Go reference.
+
+The harness lives in `crates/core/tests/charon_parity.rs` plus its
+sibling submodules; run it with:
+
+```bash
+cargo test -p pluto-core --test charon_parity --all-features -- --nocapture
+```
+
+`--nocapture` lets the per-run `ParitySummary` reach stdout — useful as
+a porting progress dashboard.
+
+## Fixture format
+
+```jsonc
+{
+  "name": "scenario_id",                       // stable identifier
+  "endpoint": "submit_proposal",               // Handler method name
+  "status":   "implemented",                   // "implemented" | "unimplemented" | "partial"
+  "go_source": "core/validatorapi/validatorapi.go:551-605",   // optional citation
+  "go_test":   "core/validatorapi/validatorapi_test.go:TestSubmitProposal",
+  "setup": {                                   // optional
+    "beacon_mock": {
+      "use_validator_set_a": true,
+      "deterministic_proposer_duties": 1,
+      "deterministic_attester_duties": null
+    },
+    "share_idx": 1,
+    "builder_enabled": false
+  },
+  "request": {
+    "kind": "submit_proposal",                 // tag matches `endpoint`
+    "proposal": { /* typed payload, or {} for pending */ }
+  },
+  "expected": {                                // omit when status="unimplemented"
+    "kind": "ok",                              // "ok" | "err"
+    "body": { /* JSON-deep-equality target */ }
+  },
+  "notes": "Optional. Short, surfaced on failure."
+}
+```
+
+### Status semantics
+
+| Status            | Run behaviour                                                                                              |
+|-------------------|------------------------------------------------------------------------------------------------------------|
+| `implemented`     | Handler must return exactly `expected`. Any panic, any mismatch ⇒ **fail**.                                |
+| `unimplemented`   | Handler must panic with `unimplemented!()`. Returning Ok/Err is a **graduation candidate** — fail loudly. |
+| `partial`         | Handler call is run, but outcome is **logged, not compared**. Use sparingly for known, tracked TODOs.     |
+
+### Pending fixtures
+
+`status: "unimplemented"` fixtures may set their `request.{opts, proposal, …}`
+payload to `{}` or `[]`. The harness substitutes a hardcoded stub
+value (see `stub_*` helpers in `tests/charon_parity/harness.rs`) for
+complex payload types like `VersionedSignedProposal` — the handler
+panics with `unimplemented!()` before reading the value, so the
+substituted stub never reaches user code.
+
+Once an endpoint is ported, the corresponding stub starts returning
+`Ok(...)` instead of panicking. The harness then flags the fixture as
+a "graduation candidate" and fails the run, forcing the porter to:
+
+1. Move the fixture from `pending.json` into one or more scenario
+   files under the same endpoint directory.
+2. Set `status: "implemented"` and fill in `expected.body` with the
+   real response shape (or `expected.kind: "err"` for failure paths).
+3. Cite the Charon test source in `go_test`.
+
+### Setup primitives (V1)
+
+- `beacon_mock.use_validator_set_a` — registers Charon's built-in
+  `validator_set_a` (3 active validators with known pubkeys).
+- `beacon_mock.deterministic_proposer_duties: <factor>` — seeds the
+  mock with Charon's `WithDeterministicProposerDuties(factor)`.
+- `beacon_mock.deterministic_attester_duties: <factor>` — same for
+  attester duties.
+- `share_idx` — threshold BLS share index (default `1`).
+- `builder_enabled` — toggles the Component's builder mode flag.
+
+DutyDB pre-population and hook registration are out of scope for V1 —
+add them when the first dutydb/hook-dependent endpoint graduates from
+`unimplemented` to `implemented`.
+
+## Adding fixtures for a newly-ported endpoint
+
+1. `cargo test -p pluto-core --test charon_parity` — confirm the
+   harness currently passes (the `pending.json` for your endpoint
+   should be in the "pending" tally).
+2. Port the endpoint as usual. Re-run; the harness will now fail with
+   a graduation message.
+3. Replace the endpoint's `pending.json` with one or more scenario
+   files (`happy_path.json`, `upstream_400.json`, …). Pin
+   `expected.body` from Charon's test fixtures
+   (`charon/core/validatorapi/testdata/...`) where available, or by
+   capturing Pluto's own response and cross-checking against Go.
+4. Cite the Charon test name in each fixture's `go_test` field.
+
+## Out of scope (deferred)
+
+- Dual-server differential testing (running real Charon + Pluto behind
+  HTTP and diffing responses). A heavier follow-up.
+- Auto-extraction of fixtures from Charon's Go table tests. Manual for
+  now; the citation fields make later migration mechanical.
+- Header-level checks (`Eth-Consensus-Version`, content-type
+  negotiation). Lives in the router, not the Handler — track
+  separately if needed.

--- a/crates/core/testdata/charon-parity/aggregate_attestation/pending.json
+++ b/crates/core/testdata/charon-parity/aggregate_attestation/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "aggregate_attestation_pending",
+  "endpoint": "aggregate_attestation",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (AggregateAttestation)",
+  "request": {
+    "kind": "aggregate_attestation",
+    "opts": {}
+  },
+  "notes": "Pluto stub. When ported, cover the dutydb await on (slot, attestation_data_root) with happy-path and timeout."
+}

--- a/crates/core/testdata/charon-parity/beacon_committee_selections/pending.json
+++ b/crates/core/testdata/charon-parity/beacon_committee_selections/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "beacon_committee_selections_pending",
+  "endpoint": "beacon_committee_selections",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitBeaconCommitteeSelections)",
+  "request": {
+    "kind": "beacon_committee_selections",
+    "selections": []
+  },
+  "notes": "Pluto stub. When ported, cover BLS verification + AggSigDB await + per-validator selection envelope shape."
+}

--- a/crates/core/testdata/charon-parity/proposal/pending.json
+++ b/crates/core/testdata/charon-parity/proposal/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "proposal_pending",
+  "endpoint": "proposal",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go:388-450",
+  "request": {
+    "kind": "proposal",
+    "opts": {}
+  },
+  "notes": "Pluto stub on main; the in-flight port is PR #461. When that lands, replace this fixture with implemented cases covering randao fan-out, v3 block-value override, dutydb fallback, etc."
+}

--- a/crates/core/testdata/charon-parity/submit_aggregate_attestations/pending.json
+++ b/crates/core/testdata/charon-parity/submit_aggregate_attestations/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_aggregate_attestations_pending",
+  "endpoint": "submit_aggregate_attestations",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitAggregateAttestations / V2)",
+  "request": {
+    "kind": "submit_aggregate_attestations",
+    "aggregates": []
+  },
+  "notes": "Pluto stub. When ported, cover the parsig fan-out and the selection-proof verify branch."
+}

--- a/crates/core/testdata/charon-parity/submit_attestations/pending.json
+++ b/crates/core/testdata/charon-parity/submit_attestations/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_attestations_pending",
+  "endpoint": "submit_attestations",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitAttestations / SubmitAttestationsV2)",
+  "request": {
+    "kind": "submit_attestations",
+    "attestations": []
+  },
+  "notes": "Pluto stub on main. When ported, replace this fixture with implemented cases covering: typed attestation set, parsig fan-out to subscribers, version mismatch rejection, etc."
+}

--- a/crates/core/testdata/charon-parity/submit_blinded_proposal/pending.json
+++ b/crates/core/testdata/charon-parity/submit_blinded_proposal/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_blinded_proposal_pending",
+  "endpoint": "submit_blinded_proposal",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go:606-673",
+  "request": {
+    "kind": "submit_blinded_proposal",
+    "proposal": {}
+  },
+  "notes": "Pluto stub on main; in-flight on PR #461. When ported, mirror the blinded-side of propDataMatchesDuty (Blinded=true forced on wrapper)."
+}

--- a/crates/core/testdata/charon-parity/submit_proposal/pending.json
+++ b/crates/core/testdata/charon-parity/submit_proposal/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_proposal_pending",
+  "endpoint": "submit_proposal",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go:551-605",
+  "request": {
+    "kind": "submit_proposal",
+    "proposal": {}
+  },
+  "notes": "Pluto stub on main; in-flight on PR #461. When ported, cover propDataMatchesDuty version/blinded/proposer-index/root branches and the parsig fan-out path."
+}

--- a/crates/core/testdata/charon-parity/submit_sync_committee_contributions/pending.json
+++ b/crates/core/testdata/charon-parity/submit_sync_committee_contributions/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_sync_committee_contributions_pending",
+  "endpoint": "submit_sync_committee_contributions",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitSyncCommitteeContributions)",
+  "request": {
+    "kind": "submit_sync_committee_contributions",
+    "contributions": []
+  },
+  "notes": "Pluto stub. When ported, cover the SignedContributionAndProof parsig fan-out."
+}

--- a/crates/core/testdata/charon-parity/submit_sync_committee_messages/pending.json
+++ b/crates/core/testdata/charon-parity/submit_sync_committee_messages/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_sync_committee_messages_pending",
+  "endpoint": "submit_sync_committee_messages",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitSyncCommitteeMessages)",
+  "request": {
+    "kind": "submit_sync_committee_messages",
+    "messages": []
+  },
+  "notes": "Pluto stub. When ported, cover the SyncCommitteeMessage parsig fan-out."
+}

--- a/crates/core/testdata/charon-parity/submit_validator_registrations/pending.json
+++ b/crates/core/testdata/charon-parity/submit_validator_registrations/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_validator_registrations_pending",
+  "endpoint": "submit_validator_registrations",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitValidatorRegistrations)",
+  "request": {
+    "kind": "submit_validator_registrations",
+    "registrations": []
+  },
+  "notes": "Pluto stub. When ported, cover both V1 and current envelopes plus the builder-domain partial-sig verification."
+}

--- a/crates/core/testdata/charon-parity/submit_voluntary_exit/pending.json
+++ b/crates/core/testdata/charon-parity/submit_voluntary_exit/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "submit_voluntary_exit_pending",
+  "endpoint": "submit_voluntary_exit",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitVoluntaryExit)",
+  "request": {
+    "kind": "submit_voluntary_exit",
+    "exit": {}
+  },
+  "notes": "Pluto stub. When ported, cover the SignedVoluntaryExit partial-sig fan-out + Exit-domain verify."
+}

--- a/crates/core/testdata/charon-parity/sync_committee_contribution/pending.json
+++ b/crates/core/testdata/charon-parity/sync_committee_contribution/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "sync_committee_contribution_pending",
+  "endpoint": "sync_committee_contribution",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SyncCommitteeContribution)",
+  "request": {
+    "kind": "sync_committee_contribution",
+    "opts": {}
+  },
+  "notes": "Pluto stub. When ported, cover the dutydb await on (slot, subcommittee_index, beacon_block_root)."
+}

--- a/crates/core/testdata/charon-parity/sync_committee_selections/pending.json
+++ b/crates/core/testdata/charon-parity/sync_committee_selections/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "sync_committee_selections_pending",
+  "endpoint": "sync_committee_selections",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (SubmitSyncCommitteeSelections)",
+  "request": {
+    "kind": "sync_committee_selections",
+    "selections": []
+  },
+  "notes": "Pluto stub. Mirrors the beacon-committee selection path; cover the same shape once ported."
+}

--- a/crates/core/testdata/charon-parity/validators/pending.json
+++ b/crates/core/testdata/charon-parity/validators/pending.json
@@ -1,0 +1,11 @@
+{
+  "name": "validators_pending",
+  "endpoint": "validators",
+  "status": "unimplemented",
+  "go_source": "core/validatorapi/validatorapi.go (Validators)",
+  "request": {
+    "kind": "validators",
+    "opts": {}
+  },
+  "notes": "Pluto stub. When ported, cover the pubkey-rewrite path that swaps root pubkeys for this node's pubshares before returning."
+}

--- a/crates/core/tests/charon_parity/fixture.rs
+++ b/crates/core/tests/charon_parity/fixture.rs
@@ -1,0 +1,213 @@
+//! Serde types for the Charon-parity fixture-replay harness.
+//!
+//! See `crates/core/testdata/charon-parity/README.md` for the wire
+//! format and porting status semantics.
+
+use serde::Deserialize;
+
+/// One fixture: a single `(handler, scenario)` test case.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Fixture {
+    /// Stable identifier of the scenario, e.g. `"node_version_basic"`.
+    pub name: String,
+
+    /// Which [`Handler`](pluto_core::validatorapi::handler::Handler) method
+    /// to drive. Tag for the [`Request`] dispatch enum.
+    pub endpoint: Endpoint,
+
+    /// Porting state of this handler. Drives whether a successful call,
+    /// a panic, or a divergence is treated as pass or fail.
+    pub status: Status,
+
+    /// Citation: Charon source file:line for the Go reference.
+    /// Surfaced in fixture-author tooling; the harness itself doesn't
+    /// read it, but the field is required so fixtures stay self-documenting.
+    #[serde(default)]
+    #[allow(
+        dead_code,
+        reason = "documentation field; read by tooling, not by the harness"
+    )]
+    pub go_source: Option<String>,
+
+    /// Citation: Charon test file:case for the expected-behaviour anchor.
+    #[serde(default)]
+    #[allow(
+        dead_code,
+        reason = "documentation field; read by tooling, not by the harness"
+    )]
+    pub go_test: Option<String>,
+
+    /// State seeded into the `Component` before the dispatch runs.
+    #[serde(default)]
+    pub setup: Setup,
+
+    /// Inbound request payload routed to the handler.
+    pub request: Request,
+
+    /// Expected response. Omitted when [`Status::Unimplemented`].
+    #[serde(default)]
+    pub expected: Option<Expected>,
+
+    /// Free-form notes that survive into the failure output.
+    #[serde(default)]
+    #[allow(
+        dead_code,
+        reason = "documentation field; surfaced manually on diff inspection"
+    )]
+    pub notes: Option<String>,
+}
+
+/// Which Handler trait method this fixture drives. The variant name
+/// maps 1:1 to the trait method name.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Endpoint {
+    NodeVersion,
+    ProposerDuties,
+    AttesterDuties,
+    SyncCommitteeDuties,
+    AttestationData,
+    SubmitAttestations,
+    Proposal,
+    SubmitProposal,
+    SubmitBlindedProposal,
+    AggregateAttestation,
+    SubmitAggregateAttestations,
+    BeaconCommitteeSelections,
+    SyncCommitteeSelections,
+    Validators,
+    SubmitValidatorRegistrations,
+    SubmitVoluntaryExit,
+    SyncCommitteeContribution,
+    SubmitSyncCommitteeContributions,
+    SubmitSyncCommitteeMessages,
+}
+
+impl Endpoint {
+    /// Returns the snake-case method name. Used in failure messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NodeVersion => "node_version",
+            Self::ProposerDuties => "proposer_duties",
+            Self::AttesterDuties => "attester_duties",
+            Self::SyncCommitteeDuties => "sync_committee_duties",
+            Self::AttestationData => "attestation_data",
+            Self::SubmitAttestations => "submit_attestations",
+            Self::Proposal => "proposal",
+            Self::SubmitProposal => "submit_proposal",
+            Self::SubmitBlindedProposal => "submit_blinded_proposal",
+            Self::AggregateAttestation => "aggregate_attestation",
+            Self::SubmitAggregateAttestations => "submit_aggregate_attestations",
+            Self::BeaconCommitteeSelections => "beacon_committee_selections",
+            Self::SyncCommitteeSelections => "sync_committee_selections",
+            Self::Validators => "validators",
+            Self::SubmitValidatorRegistrations => "submit_validator_registrations",
+            Self::SubmitVoluntaryExit => "submit_voluntary_exit",
+            Self::SyncCommitteeContribution => "sync_committee_contribution",
+            Self::SubmitSyncCommitteeContributions => "submit_sync_committee_contributions",
+            Self::SubmitSyncCommitteeMessages => "submit_sync_committee_messages",
+        }
+    }
+}
+
+/// Porting state of the handler under test.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    /// Handler is wired. Expect [`Expected`] to match the returned value
+    /// exactly.
+    Implemented,
+    /// Handler is still an `unimplemented!()` stub. Expect a panic whose
+    /// payload mentions "not yet" (the Pluto convention). Any other
+    /// outcome — Ok return or a different panic — is a hard failure that
+    /// signals the fixture needs graduation to [`Self::Implemented`].
+    Unimplemented,
+    /// Handler is wired but currently diverges from Charon in a known
+    /// way. Logged in the summary; does not fail the run. Use sparingly,
+    /// always with a `notes` field explaining the divergence.
+    Partial,
+}
+
+/// State seeded into the `Component` before the handler runs.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Setup {
+    /// Configures the upstream beacon mock. When unset, the mock is
+    /// built with `BeaconMock::builder().build()` defaults (Charon's
+    /// Charon-compatible spec).
+    #[serde(default)]
+    pub beacon_mock: BeaconMockSetup,
+
+    /// Threshold BLS share index assigned to the simulated node. Default
+    /// is `1`.
+    #[serde(default = "default_share_idx")]
+    pub share_idx: u64,
+
+    /// Whether builder mode is enabled on the Component. Default `false`.
+    #[serde(default)]
+    pub builder_enabled: bool,
+}
+
+fn default_share_idx() -> u64 {
+    1
+}
+
+/// BeaconMock configuration knobs. Only the most common knobs are
+/// exposed in the fixture wire format; grow this as fixtures need more.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct BeaconMockSetup {
+    /// Seeds the mock to serve deterministic proposer duties for the
+    /// builtin `validator_set_a`. The value is the `factor` Charon's
+    /// `WithDeterministicProposerDuties` takes.
+    #[serde(default)]
+    pub deterministic_proposer_duties: Option<u64>,
+
+    /// Seeds deterministic attester duties for `validator_set_a`. See
+    /// `pluto_testutil::beaconmock::BeaconMock`.
+    #[serde(default)]
+    pub deterministic_attester_duties: Option<u64>,
+
+    /// When set, registers the builtin `validator_set_a` so endpoints
+    /// that introspect the active set (proposer duties, attester duties)
+    /// have something to return.
+    #[serde(default)]
+    pub use_validator_set_a: bool,
+}
+
+/// Tags the Handler method to dispatch. V1 of the harness always uses
+/// a hardcoded stub value for the handler's input (see the `stub_*`
+/// helpers in `harness.rs`), so any per-endpoint payload fields in the
+/// fixture JSON (`opts`, `proposal`, `attestations`, …) are accepted
+/// for documentation but ignored at runtime. A V2 follow-up can grow
+/// this struct into typed variants once the placeholder types in
+/// `validatorapi::types` derive `Deserialize`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {
+    pub kind: Endpoint,
+}
+
+impl Request {
+    /// The endpoint tag this request targets. Used to cross-check the
+    /// fixture's `endpoint` field against the request `kind`.
+    pub fn endpoint(&self) -> Endpoint {
+        self.kind
+    }
+}
+
+/// Expected outcome of the handler call. Used only when
+/// [`Status::Implemented`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Expected {
+    /// Handler is expected to return `Ok(payload)`. The harness
+    /// serialises the actual response and deep-compares against `body`.
+    Ok { body: serde_json::Value },
+    /// Handler is expected to return `Err(ApiError)`. Compares
+    /// `status_code` and the `{code, message}` envelope; source-chain
+    /// strings are intentionally ignored to keep fixtures portable
+    /// across Rust toolchain versions.
+    Err {
+        status_code: u16,
+        #[serde(default)]
+        message: Option<String>,
+    },
+}

--- a/crates/core/tests/charon_parity/harness.rs
+++ b/crates/core/tests/charon_parity/harness.rs
@@ -1,0 +1,592 @@
+//! Driver for the Charon-parity fixture-replay harness.
+//!
+//! - [`load_all`] walks the testdata directory and parses every `*.json`
+//!   fixture.
+//! - [`build_component`] wires a [`Component`] from a fixture's [`Setup`] block
+//!   — a `BeaconMock` plus a never-expiring [`MemDB`].
+//! - [`dispatch`] routes a fixture's [`Request`] to the matching `Handler`
+//!   method. For [`Status::Unimplemented`] fixtures with complex payload types
+//!   it substitutes a hardcoded stub value, so the fixture JSON can stay
+//!   minimal — the stub handler panics before reading the value anyway. For
+//!   [`Status::Implemented`] / [`Status::Partial`] the JSON is parsed strictly.
+//! - [`compare_ok`] / [`compare_err`] deep-diff actual vs expected.
+//! - [`is_unimplemented_panic`] inspects a caught panic payload and confirms it
+//!   came from an `unimplemented!()` macro.
+//! - [`ParitySummary`] tallies how many fixtures passed / are still pending /
+//!   are flagged partial.
+
+use std::{collections::HashMap, fmt, fs, path::Path, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use futures::FutureExt;
+use pluto_core::{
+    deadline::{DeadlineCalculator, DeadlinerTask, Result as DeadlineResult},
+    dutydb::MemDB,
+    types::Duty,
+    validatorapi::{
+        component::Component,
+        error::ApiError,
+        handler::Handler,
+        types::{
+            AggregateAttestationOpts, AttestationDataOpts, AttesterDutiesOpts, ProposalOpts,
+            ProposerDutiesOpts, SignedVoluntaryExit, SyncCommitteeContributionOpts,
+            SyncCommitteeDutiesOpts, ValidatorsOpts, VersionedSignedBlindedProposal,
+            VersionedSignedProposal,
+        },
+    },
+};
+use pluto_eth2api::{EthBeaconNodeApiClient, spec::phase0::BLSPubKey};
+use pluto_testutil::{BeaconMock, ValidatorSet};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::fixture::{Endpoint, Expected, Fixture, Request, Setup, Status};
+
+/// Recursively loads every `*.json` fixture under `root`.
+pub fn load_all(root: &Path) -> Vec<(std::path::PathBuf, Fixture)> {
+    let mut out = vec![];
+    walk(root, &mut out);
+    out.sort_by(|(a, _), (b, _)| a.cmp(b));
+    out
+}
+
+fn walk(dir: &Path, out: &mut Vec<(std::path::PathBuf, Fixture)>) {
+    let read = match fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(err) => panic!("read_dir {}: {err}", dir.display()),
+    };
+    for entry in read {
+        let entry = entry.expect("readdir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, out);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let raw = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+        let fixture: Fixture = serde_json::from_str(&raw)
+            .unwrap_or_else(|err| panic!("parse {}: {err}", path.display()));
+        if fixture.endpoint != fixture.request.endpoint() {
+            panic!(
+                "{}: endpoint `{}` does not match request kind `{}`",
+                path.display(),
+                fixture.endpoint.as_str(),
+                fixture.request.endpoint().as_str(),
+            );
+        }
+        if fixture.status == Status::Implemented && fixture.expected.is_none() {
+            panic!(
+                "{}: status=implemented requires an `expected` block",
+                path.display()
+            );
+        }
+        out.push((path, fixture));
+    }
+}
+
+/// Schedules every duty with `MAX_UTC`, so duties stay `Scheduled` but
+/// never naturally expire. Mirrors the `FarFutureCalculator` used in
+/// `validatorapi::component` tests; copied locally because it is not
+/// pub-exported.
+struct FarFutureCalculator;
+
+impl DeadlineCalculator for FarFutureCalculator {
+    fn deadline(&self, _: &Duty) -> DeadlineResult<Option<DateTime<Utc>>> {
+        Ok(Some(DateTime::<Utc>::MAX_UTC))
+    }
+}
+
+/// Wires a `Component` from the fixture's `Setup`. The held `_mock`
+/// and `_cancel` keep the upstream mock server + deadliner background
+/// task alive for the full dispatch; they are dropped at the end of
+/// `evaluate`.
+pub struct BuiltComponent {
+    pub component: Component,
+    pub _mock: BeaconMock,
+    pub _cancel: CancellationToken,
+}
+
+pub async fn build_component(setup: &Setup) -> BuiltComponent {
+    let mock = build_mock(setup).await;
+    let cancel = CancellationToken::new();
+    let (deadliner, _deadliner_rx) =
+        DeadlinerTask::start(cancel.clone(), "charon-parity", FarFutureCalculator);
+    let (_evict_tx, evict_rx) = mpsc::channel(1);
+    let dutydb = Arc::new(MemDB::new(deadliner, evict_rx, &cancel));
+    let eth2_cl = Arc::new(
+        EthBeaconNodeApiClient::with_base_url(mock.uri())
+            .expect("build EthBeaconNodeApiClient from mock URI"),
+    );
+
+    // V1 leaves `pub_share_by_pubkey` empty because none of the
+    // currently-implemented handlers on `main` invoke partial-signature
+    // verification. Submit handlers will need to populate this once they
+    // graduate from `unimplemented!()`.
+    let pub_share_by_pubkey: HashMap<BLSPubKey, BLSPubKey> = HashMap::new();
+
+    let component = Component::new(
+        eth2_cl,
+        dutydb,
+        setup.share_idx,
+        pub_share_by_pubkey,
+        setup.builder_enabled,
+    );
+
+    BuiltComponent {
+        component,
+        _mock: mock,
+        _cancel: cancel,
+    }
+}
+
+async fn build_mock(setup: &Setup) -> BeaconMock {
+    let m = &setup.beacon_mock;
+    // `bon`'s typestate setters can each be called at most once, so
+    // route every conditional through the `maybe_*` variant which takes
+    // `Option<T>` and is a no-op when the option is `None`.
+    BeaconMock::builder()
+        .maybe_validator_set(m.use_validator_set_a.then(ValidatorSet::validator_set_a))
+        .maybe_deterministic_proposer_duties(m.deterministic_proposer_duties)
+        .maybe_deterministic_attester_duties(m.deterministic_attester_duties)
+        .build()
+        .await
+        .expect("build beacon mock")
+}
+
+/// Either a JSON-serialised success body or a structured error summary.
+#[derive(Debug)]
+pub enum Outcome {
+    Ok(serde_json::Value),
+    Err { status_code: u16, message: String },
+}
+
+/// Routes a fixture to the matching Handler trait method. V1 builds
+/// every input value from a hardcoded stub helper — the fixture's
+/// `request` field only tags the endpoint. Implemented handlers
+/// (`node_version`, `proposer_duties`, …) see fixed inputs;
+/// unimplemented handlers panic before reading anything. A V2
+/// follow-up can move to per-fixture parameterised inputs once the
+/// placeholder types in `validatorapi::types` derive `Deserialize`.
+///
+/// Any panic (including `unimplemented!()`) propagates out — the
+/// caller catches it with `FutureExt::catch_unwind`.
+pub async fn dispatch(component: &Component, request: &Request, _status: Status) -> Outcome {
+    match request.kind {
+        Endpoint::NodeVersion => unwrap_eth(component.node_version().await, |r| {
+            serde_json::to_value(&r).expect("serialize NodeVersionResponse")
+        }),
+        Endpoint::ProposerDuties => unwrap_eth(
+            component.proposer_duties(stub_proposer_duties_opts()).await,
+            |r| serde_json::to_value(&r).expect("serialize ProposerDutiesResponse"),
+        ),
+        Endpoint::AttesterDuties => unwrap_eth(
+            component.attester_duties(stub_attester_duties_opts()).await,
+            |r| serde_json::to_value(&r).expect("serialize AttesterDutiesResponse"),
+        ),
+        Endpoint::SyncCommitteeDuties => unwrap_eth(
+            component
+                .sync_committee_duties(stub_sync_committee_duties_opts())
+                .await,
+            |r| serde_json::to_value(&r).expect("serialize SyncCommitteeDutiesResponse"),
+        ),
+        Endpoint::AttestationData => unwrap_eth(
+            component
+                .attestation_data(stub_attestation_data_opts())
+                .await,
+            |r| serde_json::to_value(&r.data).expect("serialize AttestationData"),
+        ),
+        Endpoint::SubmitAttestations => unwrap_unit(component.submit_attestations(vec![]).await),
+        Endpoint::Proposal => unwrap_eth(
+            component.proposal(stub_proposal_opts()).await,
+            // EthResponse<VersionedProposal> doesn't derive Serialize
+            // on `main`; reconstruct the wire shape by hand. The
+            // handler is a stub on main, so this path mostly exercises
+            // the unimplemented-panic branch.
+            |r| {
+                serde_json::json!({
+                    "execution_optimistic": r.execution_optimistic,
+                    "finalized": r.finalized,
+                    "dependent_root": r.dependent_root,
+                })
+            },
+        ),
+        Endpoint::SubmitProposal => {
+            unwrap_unit(component.submit_proposal(stub_signed_proposal()).await)
+        }
+        Endpoint::SubmitBlindedProposal => unwrap_unit(
+            component
+                .submit_blinded_proposal(stub_signed_blinded_proposal())
+                .await,
+        ),
+        Endpoint::AggregateAttestation => unwrap_eth(
+            component
+                .aggregate_attestation(stub_aggregate_attestation_opts())
+                .await,
+            |_| serde_json::Value::Null,
+        ),
+        Endpoint::SubmitAggregateAttestations => {
+            unwrap_unit(component.submit_aggregate_attestations(vec![]).await)
+        }
+        Endpoint::BeaconCommitteeSelections => {
+            unwrap_eth(component.beacon_committee_selections(vec![]).await, |_| {
+                serde_json::Value::Null
+            })
+        }
+        Endpoint::SyncCommitteeSelections => {
+            unwrap_eth(component.sync_committee_selections(vec![]).await, |_| {
+                serde_json::Value::Null
+            })
+        }
+        Endpoint::Validators => {
+            unwrap_eth(component.validators(stub_validators_opts()).await, |_| {
+                serde_json::Value::Null
+            })
+        }
+        Endpoint::SubmitValidatorRegistrations => {
+            unwrap_unit(component.submit_validator_registrations(vec![]).await)
+        }
+        Endpoint::SubmitVoluntaryExit => {
+            unwrap_unit(component.submit_voluntary_exit(stub_voluntary_exit()).await)
+        }
+        Endpoint::SyncCommitteeContribution => unwrap_eth(
+            component
+                .sync_committee_contribution(stub_sync_committee_contribution_opts())
+                .await,
+            |_| serde_json::Value::Null,
+        ),
+        Endpoint::SubmitSyncCommitteeContributions => {
+            unwrap_unit(component.submit_sync_committee_contributions(vec![]).await)
+        }
+        Endpoint::SubmitSyncCommitteeMessages => {
+            unwrap_unit(component.submit_sync_committee_messages(vec![]).await)
+        }
+    }
+}
+
+fn unwrap_eth<T>(
+    result: Result<T, ApiError>,
+    to_json: impl FnOnce(T) -> serde_json::Value,
+) -> Outcome {
+    match result {
+        Ok(v) => Outcome::Ok(to_json(v)),
+        Err(err) => api_error_to_outcome(err),
+    }
+}
+
+fn unwrap_unit(result: Result<(), ApiError>) -> Outcome {
+    match result {
+        Ok(()) => Outcome::Ok(serde_json::Value::Null),
+        Err(err) => api_error_to_outcome(err),
+    }
+}
+
+fn api_error_to_outcome(err: ApiError) -> Outcome {
+    Outcome::Err {
+        status_code: err.status_code.as_u16(),
+        message: err.message.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stub builders for the Unimplemented dispatch path.
+//
+// These return the bare-minimum value the handler's input type accepts.
+// The matching handler is currently `unimplemented!()` and panics before
+// reading the value, so contents are irrelevant — they just need to
+// typecheck.
+// ---------------------------------------------------------------------------
+
+fn stub_proposer_duties_opts() -> ProposerDutiesOpts {
+    ProposerDutiesOpts { epoch: 0 }
+}
+
+fn stub_attester_duties_opts() -> AttesterDutiesOpts {
+    AttesterDutiesOpts {
+        epoch: 0,
+        indices: vec![],
+    }
+}
+
+fn stub_sync_committee_duties_opts() -> SyncCommitteeDutiesOpts {
+    SyncCommitteeDutiesOpts {
+        epoch: 0,
+        indices: vec![],
+    }
+}
+
+fn stub_attestation_data_opts() -> AttestationDataOpts {
+    AttestationDataOpts {
+        slot: 0,
+        committee_index: 0,
+    }
+}
+
+fn stub_proposal_opts() -> ProposalOpts {
+    ProposalOpts {
+        slot: 0,
+        randao_reveal: [0; 96],
+        graffiti: [0; 32],
+        builder_boost_factor: None,
+    }
+}
+
+fn stub_aggregate_attestation_opts() -> AggregateAttestationOpts {
+    AggregateAttestationOpts {
+        slot: 0,
+        attestation_data_root: [0; 32],
+        committee_index: 0,
+    }
+}
+
+fn stub_validators_opts() -> ValidatorsOpts {
+    ValidatorsOpts {
+        state: "head".to_string(),
+        pubkeys: vec![],
+        indices: vec![],
+    }
+}
+
+fn stub_sync_committee_contribution_opts() -> SyncCommitteeContributionOpts {
+    SyncCommitteeContributionOpts {
+        slot: 0,
+        subcommittee_index: 0,
+        beacon_block_root: [0; 32],
+    }
+}
+
+// `SignedVoluntaryExit`, `VersionedSignedProposal`, and
+// `VersionedSignedBlindedProposal` are placeholder `{}` structs on
+// `main`; PR #461 replaces them with `signeddata::*` / `versioned::*`
+// re-exports. Construct via literal — when those re-exports land, this
+// V1 harness will fail to compile and the porter will need to update
+// the stubs to construct real values.
+fn stub_voluntary_exit() -> SignedVoluntaryExit {
+    SignedVoluntaryExit {}
+}
+
+fn stub_signed_proposal() -> VersionedSignedProposal {
+    VersionedSignedProposal {}
+}
+
+fn stub_signed_blinded_proposal() -> VersionedSignedBlindedProposal {
+    VersionedSignedBlindedProposal {}
+}
+
+/// Deep-diff `actual` against the expected fixture body. Returns
+/// `Ok(())` on match, `Err(diff_string)` on mismatch.
+pub fn compare_ok(actual: &serde_json::Value, expected: &serde_json::Value) -> Result<(), String> {
+    if actual == expected {
+        return Ok(());
+    }
+    let actual_pretty =
+        serde_json::to_string_pretty(actual).expect("serialise actual JSON for diff");
+    let expected_pretty =
+        serde_json::to_string_pretty(expected).expect("serialise expected JSON for diff");
+    Err(format!(
+        "json mismatch:\n--- expected ---\n{expected_pretty}\n--- actual ---\n{actual_pretty}",
+    ))
+}
+
+/// Returns `Ok(())` if the structured error matches the expected
+/// status + (optional) message envelope.
+pub fn compare_err(
+    actual_status: u16,
+    actual_message: &str,
+    expected: &Expected,
+) -> Result<(), String> {
+    let Expected::Err {
+        status_code,
+        message,
+    } = expected
+    else {
+        return Err(format!(
+            "actual was Err({actual_status}, {actual_message:?}) but expected `ok` body"
+        ));
+    };
+    if *status_code != actual_status {
+        return Err(format!(
+            "status_code mismatch: expected {status_code}, got {actual_status} (message: {actual_message:?})",
+        ));
+    }
+    if let Some(expected_msg) = message
+        && expected_msg != actual_message
+    {
+        return Err(format!(
+            "message mismatch: expected {expected_msg:?}, got {actual_message:?}",
+        ));
+    }
+    Ok(())
+}
+
+/// Inspects a caught panic payload to decide whether it came from an
+/// `unimplemented!()` macro. The std macro formats with
+/// `"not yet implemented: <msg>"`, and Pluto's stubs use messages like
+/// `"submit_attestations not yet ported"` — either pattern counts.
+pub fn is_unimplemented_panic(payload: &(dyn std::any::Any + Send)) -> Option<String> {
+    let msg = payload
+        .downcast_ref::<&'static str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())?;
+    if msg.starts_with("not yet implemented")
+        || msg.contains("not yet ported")
+        || msg.contains("not yet stubbed")
+    {
+        Some(msg)
+    } else {
+        None
+    }
+}
+
+/// Tally of fixture outcomes for the test's stdout summary.
+#[derive(Debug, Default)]
+pub struct ParitySummary {
+    pub implemented_pass: usize,
+    pub pending: usize,
+    pub partial: usize,
+    pub failures: Vec<String>,
+}
+
+impl ParitySummary {
+    pub fn record_pass(&mut self) {
+        self.implemented_pass = self.implemented_pass.saturating_add(1);
+    }
+
+    pub fn record_pending(&mut self) {
+        self.pending = self.pending.saturating_add(1);
+    }
+
+    pub fn record_partial(&mut self) {
+        self.partial = self.partial.saturating_add(1);
+    }
+
+    pub fn record_failure(&mut self, name: &str, detail: impl Into<String>) {
+        self.failures.push(format!("[{name}] {}", detail.into()));
+    }
+
+    pub fn total(&self) -> usize {
+        self.implemented_pass
+            .saturating_add(self.pending)
+            .saturating_add(self.partial)
+            .saturating_add(self.failures.len())
+    }
+}
+
+impl fmt::Display for ParitySummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "\nCharon-parity summary ({} fixtures):", self.total())?;
+        writeln!(f, "  implemented passing: {}", self.implemented_pass)?;
+        writeln!(f, "  pending (unimplemented stubs): {}", self.pending)?;
+        writeln!(f, "  partial (known divergences): {}", self.partial)?;
+        writeln!(f, "  failed: {}", self.failures.len())?;
+        Ok(())
+    }
+}
+
+/// Drives one fixture and folds the outcome into `summary`. Returns
+/// `Err(detail)` mirroring the summary's failure list, so the caller
+/// can surface per-fixture errors if it chooses to.
+pub async fn evaluate(
+    path: &Path,
+    fixture: &Fixture,
+    summary: &mut ParitySummary,
+) -> Result<(), String> {
+    let built = build_component(&fixture.setup).await;
+    let status = fixture.status;
+    let dispatch_future = async {
+        let component = &built.component;
+        dispatch(component, &fixture.request, status).await
+    };
+    let outcome = std::panic::AssertUnwindSafe(dispatch_future)
+        .catch_unwind()
+        .await;
+
+    let result = match (fixture.status, outcome) {
+        (Status::Implemented, Ok(Outcome::Ok(actual))) => {
+            let expected = fixture
+                .expected
+                .as_ref()
+                .expect("implemented status requires expected (checked at load)");
+            match expected {
+                Expected::Ok { body } => match compare_ok(&actual, body) {
+                    Ok(()) => {
+                        summary.record_pass();
+                        Ok(())
+                    }
+                    Err(diff) => {
+                        summary.record_failure(&fixture.name, diff.clone());
+                        Err(diff)
+                    }
+                },
+                Expected::Err { .. } => {
+                    let diff = format!("expected Err response, got Ok: {actual}");
+                    summary.record_failure(&fixture.name, diff.clone());
+                    Err(diff)
+                }
+            }
+        }
+        (
+            Status::Implemented,
+            Ok(Outcome::Err {
+                status_code,
+                message,
+            }),
+        ) => {
+            let expected = fixture
+                .expected
+                .as_ref()
+                .expect("implemented status requires expected (checked at load)");
+            match compare_err(status_code, &message, expected) {
+                Ok(()) => {
+                    summary.record_pass();
+                    Ok(())
+                }
+                Err(diff) => {
+                    summary.record_failure(&fixture.name, diff.clone());
+                    Err(diff)
+                }
+            }
+        }
+        (Status::Implemented, Err(panic)) => {
+            let detail = format_panic("unexpected panic in implemented handler", &*panic);
+            summary.record_failure(&fixture.name, detail.clone());
+            Err(detail)
+        }
+        (Status::Unimplemented, Ok(outcome)) => {
+            let detail = format!(
+                "graduation candidate: {} no longer panics — returned {outcome:?}. Promote fixture to status:implemented and fill in `expected`.",
+                fixture.endpoint.as_str()
+            );
+            summary.record_failure(&fixture.name, detail.clone());
+            Err(detail)
+        }
+        (Status::Unimplemented, Err(panic)) => match is_unimplemented_panic(&*panic) {
+            Some(_) => {
+                summary.record_pending();
+                Ok(())
+            }
+            None => {
+                let detail = format_panic("non-unimplemented panic in stub", &*panic);
+                summary.record_failure(&fixture.name, detail.clone());
+                Err(detail)
+            }
+        },
+        (Status::Partial, _) => {
+            summary.record_partial();
+            Ok(())
+        }
+    };
+
+    result.map_err(|err| format!("{} ({})\n{}", fixture.name, path.display(), err))
+}
+
+fn format_panic(prefix: &str, payload: &(dyn std::any::Any + Send)) -> String {
+    let msg = payload
+        .downcast_ref::<&'static str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "<non-string panic payload>".to_string());
+    format!("{prefix}: {msg}")
+}

--- a/crates/core/tests/charon_parity/main.rs
+++ b/crates/core/tests/charon_parity/main.rs
@@ -1,0 +1,54 @@
+//! Charon-parity fixture-replay harness — entry point.
+//!
+//! Walks `crates/core/testdata/charon-parity/**/*.json`, dispatches
+//! each fixture into the matching `validatorapi::Handler` method, and
+//! records the outcome in a [`ParitySummary`]. Status-aware:
+//!
+//! - `implemented` fixtures must match their `expected` body exactly.
+//! - `unimplemented` fixtures must panic with an `unimplemented!()` payload —
+//!   confirming the stub is still in place. If the handler stops panicking, the
+//!   run **fails** as a "graduation candidate" prompting the porter to upgrade
+//!   the fixture.
+//! - `partial` fixtures are logged but never fail (use sparingly for known,
+//!   tracked divergences).
+//!
+//! Author guide for new fixtures:
+//! `crates/core/testdata/charon-parity/README.md`.
+
+mod fixture;
+mod harness;
+
+use std::path::PathBuf;
+
+use harness::{ParitySummary, evaluate, load_all};
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata")
+        .join("charon-parity")
+}
+
+#[tokio::test]
+async fn charon_parity() {
+    let root = fixtures_root();
+    let fixtures = load_all(&root);
+    assert!(
+        !fixtures.is_empty(),
+        "no fixtures found under {}",
+        root.display()
+    );
+
+    let mut summary = ParitySummary::default();
+    for (path, fixture) in &fixtures {
+        // Each fixture's result is folded into `summary`; per-fixture
+        // failures are accumulated, not propagated, so the summary
+        // covers the whole set before the final assertion fires.
+        let _ = evaluate(path, fixture, &mut summary).await;
+    }
+
+    println!("{summary}");
+    if !summary.failures.is_empty() {
+        let detail = summary.failures.join("\n\n");
+        panic!("Charon-parity harness failures:\n\n{detail}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Charon-parity fixture-replay harness that runs every `validatorapi::Handler` method through a status-aware JSON fixture driver. Today, divergences from Charon are caught only by hand-reading both source trees; this harness turns that audit into a CI test and a porting progress dashboard.

## Run it

```bash
cargo test -p pluto-core --test charon_parity --all-features -- --nocapture
```

First-run output on `main`:

```
Charon-parity summary (14 fixtures):
  implemented passing: 0
  pending (unimplemented stubs): 14
  partial (known divergences): 0
  failed: 0

test charon_parity ... ok
```

## How it works

Each JSON file in `crates/core/testdata/charon-parity/<endpoint>/<scenario>.json` carries a `status`:

| Status | Run behaviour |
|---|---|
| `implemented` | Handler must return exactly `expected`. Any panic or mismatch ⇒ **fail**. |
| `unimplemented` | Handler must panic with `unimplemented!()`. Returning Ok/Err is a **graduation candidate** — fail loudly. |
| `partial` | Logged but never fails. For known, tracked divergences. |

The driver wraps each dispatch in `FutureExt::catch_unwind` and inspects the panic payload — any `"not yet ..."` payload counts as a stub panic. When a stub graduates (panic stops firing), the harness fails until the porter promotes the fixture from `pending.json` to one or more real scenario files with `status: "implemented"` and a populated `expected` block.

## What's in V1

- Driver: `crates/core/tests/charon_parity/{main,fixture,harness}.rs` (single integration test wired via `[[test]]` in `crates/core/Cargo.toml` because the directory layout requires it).
- Author guide: `crates/core/testdata/charon-parity/README.md`.
- 14 `pending.json` fixtures — one per `unimplemented!()` stub on main (`submit_attestations`, `proposal`, `submit_proposal`, `submit_blinded_proposal`, `aggregate_attestation`, `submit_aggregate_attestations`, `beacon_committee_selections`, `sync_committee_selections`, `validators`, `submit_validator_registrations`, `submit_voluntary_exit`, `sync_committee_contribution`, `submit_sync_committee_contributions`, `submit_sync_committee_messages`).

## Deferred to V2

- **Implemented fixtures.** The placeholder input types in `validatorapi/types.rs` (`VersionedSignedProposal`, `SignedVoluntaryExit`, etc.) are empty `{}` structs without `Deserialize` on main, so V1 always builds inputs from in-Rust stub helpers and the fixture's `request` field only tags the endpoint. Once the in-flight PR #461 lands and the types graduate to real `signeddata::*` / `versioned::*` re-exports, V2 can add typed `Deserialize`-driven inputs and real `implemented` fixtures (start with `node_version`, `proposer_duties`, `attester_duties`, `sync_committee_duties`, `attestation_data`).
- **Dual-server differential testing** (run Charon + Pluto side-by-side over HTTP, diff responses). Heavier follow-up.
- **Auto-extraction** of fixtures from Charon's Go table tests. The `go_source` / `go_test` citation fields make later migration mechanical.
- **Router-level checks** (`Eth-Consensus-Version`, content-type negotiation). Lives in the router, not the Handler — track separately if needed.

## Test plan

- [x] `cargo +nightly fmt --all --check`
- [x] `cargo clippy -p pluto-core --tests --all-features -- -D warnings`
- [x] `cargo test -p pluto-core --test charon_parity --all-features` — 14 fixtures, 14 pending, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)