### PR TITLE
feat(eth2api): BeaconNodeClient wraps api and validator_cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,6 +5727,7 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "validator",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/app/src/eth2wrap/mod.rs
+++ b/crates/app/src/eth2wrap/mod.rs
@@ -1,5 +1,2 @@
 /// Validate Beacon node versions
 pub mod version;
-
-/// Cache of Validators retrieved from the Beacon node
-pub mod valcache;

--- a/crates/eth2api/Cargo.toml
+++ b/crates/eth2api/Cargo.toml
@@ -31,11 +31,12 @@ tree_hash.workspace = true
 tree_hash_derive.workspace = true
 alloy.workspace = true
 pluto-ssz.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 testcontainers.workspace = true
-tokio.workspace = true
 test-case.workspace = true
+wiremock.workspace = true
 
 [build-dependencies]
 regex.workspace = true

--- a/crates/eth2api/src/beacon_node.rs
+++ b/crates/eth2api/src/beacon_node.rs
@@ -1,0 +1,162 @@
+use crate::{
+    EthBeaconNodeApiClient,
+    valcache::{ActiveValidators, CompleteValidators, ValidatorCache, ValidatorCacheError},
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+type Result<T> = std::result::Result<T, BeaconNodeClientError>;
+
+/// Errors returned by [`BeaconNodeClient`].
+#[derive(Debug, thiserror::Error)]
+pub enum BeaconNodeClientError {
+    /// Validator cache has not been configured.
+    #[error("no active validator cache")]
+    NoActiveValidatorCache,
+
+    /// Validator cache failed.
+    #[error(transparent)]
+    ValidatorCache(#[from] ValidatorCacheError),
+}
+
+/// Beacon node client with Charon/Pluto convenience state layered on top of the
+/// generated Beacon API client.
+#[derive(Clone)]
+pub struct BeaconNodeClient {
+    api: EthBeaconNodeApiClient,
+    validator_cache: Arc<RwLock<Option<ValidatorCache>>>,
+}
+
+impl BeaconNodeClient {
+    /// Creates a new beacon node client.
+    pub fn new(api: EthBeaconNodeApiClient) -> Self {
+        Self {
+            api,
+            validator_cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Returns the generated Beacon API client.
+    pub fn api(&self) -> &EthBeaconNodeApiClient {
+        &self.api
+    }
+
+    /// Sets the validator cache used by cached validator methods.
+    pub async fn set_validator_cache(&self, validator_cache: ValidatorCache) {
+        *self.validator_cache.write().await = Some(validator_cache);
+    }
+
+    /// Returns active validators for `head`.
+    pub async fn active_validators(&self) -> Result<ActiveValidators> {
+        let (active, _) = self.validator_cache().await?.get_by_head().await?;
+        Ok(active)
+    }
+
+    /// Returns complete validators for `head`.
+    pub async fn complete_validators(&self) -> Result<CompleteValidators> {
+        let (_, complete) = self.validator_cache().await?.get_by_head().await?;
+        Ok(complete)
+    }
+
+    async fn validator_cache(&self) -> Result<ValidatorCache> {
+        self.validator_cache
+            .read()
+            .await
+            .clone()
+            .ok_or(BeaconNodeClientError::NoActiveValidatorCache)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        GetStateValidatorsResponseResponse, GetStateValidatorsResponseResponseDatum,
+        ValidatorResponseValidator, ValidatorStatus, spec::phase0::BLSPubKey,
+    };
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    const EFFECTIVE_BALANCE: &str = "32000000000";
+    const ZERO_EPOCH: &str = "0";
+    const FAR_FUTURE_EPOCH: &str = "18446744073709551615";
+    const ZERO_WITHDRAWAL_CREDENTIALS: &str =
+        "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    #[tokio::test]
+    async fn active_and_complete_validators_share_cache() {
+        let pubkeys = vec![test_pubkey(1), test_pubkey(2)];
+        let mock = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/eth/v1/beacon/states/head/validators"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                GetStateValidatorsResponseResponse {
+                    execution_optimistic: false,
+                    finalized: true,
+                    data: vec![
+                        test_validator_datum(10, &pubkeys[0], ValidatorStatus::ActiveOngoing),
+                        test_validator_datum(11, &pubkeys[1], ValidatorStatus::PendingQueued),
+                    ],
+                },
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let client = BeaconNodeClient::new(test_client(&mock));
+        client
+            .set_validator_cache(ValidatorCache::new(client.api().clone(), pubkeys))
+            .await;
+
+        let active = client.active_validators().await.unwrap();
+        let complete = client.complete_validators().await.unwrap();
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(complete.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn active_validators_errors_without_cache() {
+        let mock = MockServer::start().await;
+        let client = BeaconNodeClient::new(test_client(&mock));
+
+        let err = client.active_validators().await.unwrap_err();
+
+        assert_eq!(err.to_string(), "no active validator cache");
+    }
+
+    fn test_client(server: &MockServer) -> EthBeaconNodeApiClient {
+        EthBeaconNodeApiClient::with_base_url(server.uri()).expect("valid mock server URL")
+    }
+
+    fn test_pubkey(seed: u8) -> BLSPubKey {
+        let mut bytes = [0u8; 48];
+        bytes[0] = seed;
+        bytes
+    }
+
+    fn test_validator_datum(
+        index: u64,
+        pubkey: &BLSPubKey,
+        status: ValidatorStatus,
+    ) -> GetStateValidatorsResponseResponseDatum {
+        GetStateValidatorsResponseResponseDatum {
+            index: index.to_string(),
+            balance: EFFECTIVE_BALANCE.to_string(),
+            status,
+            validator: ValidatorResponseValidator {
+                pubkey: format!("0x{}", hex::encode(pubkey)),
+                withdrawal_credentials: ZERO_WITHDRAWAL_CREDENTIALS.to_string(),
+                effective_balance: EFFECTIVE_BALANCE.to_string(),
+                slashed: false,
+                activation_eligibility_epoch: ZERO_EPOCH.to_string(),
+                activation_epoch: ZERO_EPOCH.to_string(),
+                exit_epoch: FAR_FUTURE_EPOCH.to_string(),
+                withdrawable_epoch: FAR_FUTURE_EPOCH.to_string(),
+            },
+        }
+    }
+}

--- a/crates/eth2api/src/lib.rs
+++ b/crates/eth2api/src/lib.rs
@@ -31,6 +31,9 @@ pub mod v1;
 /// Versioned wrappers for signeddata-related payloads.
 pub mod versioned;
 
+/// Cache of Validators retrieved from the Beacon node.
+pub mod valcache;
+
 #[cfg(test)]
 pub(crate) mod test_fixtures;
 

--- a/crates/eth2api/src/lib.rs
+++ b/crates/eth2api/src/lib.rs
@@ -22,6 +22,11 @@ pub mod extensions;
 
 pub use extensions::*;
 
+/// Beacon node client wrapper.
+pub mod beacon_node;
+
+pub use beacon_node::BeaconNodeClient;
+
 /// Ethereum 2.0 consensus layer specification types.
 pub mod spec;
 

--- a/crates/eth2api/src/valcache.rs
+++ b/crates/eth2api/src/valcache.rs
@@ -1,9 +1,8 @@
-use pluto_core::types::PubKey;
-use pluto_eth2api::{
+use crate::{
     EthBeaconNodeApiClient, EthBeaconNodeApiClientError, GetStateValidatorsResponseResponse,
     GetStateValidatorsResponseResponseDatum, PostStateValidatorsRequest,
     PostStateValidatorsRequestPath, PostStateValidatorsResponse, ValidatorRequestBody,
-    spec::phase0::ValidatorIndex,
+    spec::phase0::{BLSPubKey as PubKey, ValidatorIndex},
 };
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
@@ -108,7 +107,7 @@ impl ValidatorCache {
                 state_id: "head".into(),
             },
             body: ValidatorRequestBody {
-                ids: Some(inner.pubkeys.iter().map(|pk| pk.to_string()).collect()),
+                ids: Some(inner.pubkeys.iter().map(format_pubkey).collect()),
                 ..Default::default()
             },
         };
@@ -148,7 +147,7 @@ impl ValidatorCache {
                 state_id: slot.to_string(),
             },
             body: ValidatorRequestBody {
-                ids: Some(inner.pubkeys.iter().map(|pk| pk.to_string()).collect()),
+                ids: Some(inner.pubkeys.iter().map(format_pubkey).collect()),
                 ..Default::default()
             },
         };
@@ -203,12 +202,7 @@ fn validators_from_response(
         .iter()
         .filter(|(_, v)| v.status.is_active())
         .map(|(&index, v)| {
-            let pubkey = v
-                .validator
-                .pubkey
-                .as_str()
-                .try_into()
-                .map_err(|_| EthBeaconNodeApiClientError::UnexpectedType)?;
+            let pubkey = parse_pubkey(&v.validator.pubkey)?;
 
             Ok((index, pubkey))
         })
@@ -220,16 +214,29 @@ fn validators_from_response(
     ))
 }
 
+fn format_pubkey(pubkey: &PubKey) -> String {
+    format!("0x{}", hex::encode(pubkey))
+}
+
+fn parse_pubkey(pubkey: &str) -> Result<PubKey> {
+    let bytes = hex::decode(pubkey.strip_prefix("0x").unwrap_or(pubkey))
+        .map_err(|_| EthBeaconNodeApiClientError::UnexpectedType)?;
+
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| EthBeaconNodeApiClientError::UnexpectedType.into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pluto_eth2api::{
+    use crate::{
         BlindedBlock400Response, GetStateValidatorsResponseResponseDatum,
         ValidatorResponseValidator, ValidatorStatus,
     };
-    use pluto_testutil::BeaconMock;
     use wiremock::{
-        Mock, ResponseTemplate,
+        Mock, MockServer, ResponseTemplate,
         matchers::{method, path},
     };
 
@@ -262,23 +269,20 @@ mod tests {
             .iter()
             .filter(|(_, datum)| datum.status.is_active())
             .map(|(&index, datum)| {
-                let pubkey: PubKey = datum.validator.pubkey.as_str().try_into().unwrap();
+                let pubkey = parse_pubkey(&datum.validator.pubkey).unwrap();
                 (index, pubkey)
             })
             .collect::<HashMap<ValidatorIndex, PubKey>>();
 
         // Create a mock server that tracks request count
-        let mock = BeaconMock::builder()
-            .build()
-            .await
-            .expect("should create beacon mock");
+        let mock = MockServer::start().await;
         post_state_validators_success("head", datums.to_vec())
             .expect(2) // Should be called exactly twice (once before trim, once after)
-            .mount(mock.server())
+            .mount(&mock)
             .await;
 
         // Create a cache.
-        let cache = ValidatorCache::new(mock.client().clone(), pubkeys);
+        let cache = ValidatorCache::new(test_client(&mock), pubkeys.clone());
 
         // Check cache is populated.
         let (actual_active, actual_complete) =
@@ -311,16 +315,13 @@ mod tests {
     #[tokio::test]
     async fn get_by_head_fail_fetch() {
         // Create a mock server that returns a 404 error
-        let mock = BeaconMock::builder()
-            .build()
-            .await
-            .expect("should create beacon mock");
+        let mock = MockServer::start().await;
 
         post_state_validators_not_found("head")
             .expect(1)
-            .mount(mock.server())
+            .mount(&mock)
             .await;
-        let cache = ValidatorCache::new(mock.client().clone(), vec![test_pubkey(1)]);
+        let cache = ValidatorCache::new(test_client(&mock), vec![test_pubkey(1)]);
 
         // Verify cache is initially empty
         {
@@ -346,10 +347,7 @@ mod tests {
         let pubkeys = vec![test_pubkey(0), test_pubkey(1)];
 
         // Set up mock server with different responses based on slot
-        let mock = BeaconMock::builder()
-            .build()
-            .await
-            .expect("should create beacon mock");
+        let mock = MockServer::start().await;
 
         post_state_validators_success(
             "1",
@@ -358,7 +356,7 @@ mod tests {
                 test_validator_datum(1, &pubkeys[1], ValidatorStatus::ActiveOngoing),
             ],
         )
-        .mount(mock.server())
+        .mount(&mock)
         .await;
 
         post_state_validators_success(
@@ -368,7 +366,7 @@ mod tests {
                 test_validator_datum(1, &pubkeys[1], ValidatorStatus::ActiveOngoing),
             ],
         )
-        .mount(mock.server())
+        .mount(&mock)
         .await;
 
         post_state_validators_success(
@@ -378,18 +376,14 @@ mod tests {
                 test_validator_datum(1, &pubkeys[1], ValidatorStatus::PendingQueued),
             ],
         )
-        .mount(mock.server())
+        .mount(&mock)
         .await;
 
-        post_state_validators_not_found("3")
-            .mount(mock.server())
-            .await;
-        post_state_validators_not_found("head")
-            .mount(mock.server())
-            .await;
+        post_state_validators_not_found("3").mount(&mock).await;
+        post_state_validators_not_found("head").mount(&mock).await;
 
         // Create a cache.
-        let cache = ValidatorCache::new(mock.client().clone(), pubkeys.clone());
+        let cache = ValidatorCache::new(test_client(&mock), pubkeys.clone());
 
         // Test slot 1: 1 active validator (index 1), 2 complete, refreshed_by_slot=true
         let (active, complete, refreshed_by_slot) = cache
@@ -431,14 +425,9 @@ mod tests {
         let pubkeys = vec![test_pubkey(0), test_pubkey(1)];
 
         // Set up mock server: slot requests fail, but head succeeds
-        let mock = BeaconMock::builder()
-            .build()
-            .await
-            .expect("should create beacon mock");
+        let mock = MockServer::start().await;
 
-        post_state_validators_not_found("1")
-            .mount(mock.server())
-            .await;
+        post_state_validators_not_found("1").mount(&mock).await;
 
         post_state_validators_success(
             "head",
@@ -447,10 +436,10 @@ mod tests {
                 test_validator_datum(1, &pubkeys[1], ValidatorStatus::ActiveOngoing),
             ],
         )
-        .mount(mock.server())
+        .mount(&mock)
         .await;
 
-        let cache = ValidatorCache::new(mock.client().clone(), pubkeys);
+        let cache = ValidatorCache::new(test_client(&mock), pubkeys);
 
         // Test slot 1: fails, falls back to head, returns 2 active, 2 complete,
         // refreshed_by_slot=false
@@ -466,7 +455,7 @@ mod tests {
     fn test_pubkey(seed: u8) -> PubKey {
         let mut bytes = [0u8; 48];
         bytes[0] = seed;
-        PubKey::new(bytes)
+        bytes
     }
 
     fn test_validator_datum(
@@ -480,7 +469,7 @@ mod tests {
             balance: "32000000000".to_string(),
             status,
             validator: ValidatorResponseValidator {
-                pubkey: pubkey.to_string(),
+                pubkey: format_pubkey(pubkey),
                 withdrawal_credentials:
                     "0x0000000000000000000000000000000000000000000000000000000000000000".to_string(),
                 effective_balance: "32000000000".to_string(),
@@ -524,5 +513,9 @@ mod tests {
                     stacktraces: None,
                 }),
             )
+    }
+
+    fn test_client(server: &MockServer) -> EthBeaconNodeApiClient {
+        EthBeaconNodeApiClient::with_base_url(server.uri()).expect("valid mock server URL")
     }
 }


### PR DESCRIPTION
This PR moves `valcache` out from `app`, also introduces the `BeaconNodeClient` which is `eth2wrap.Client` in Charon which wraps `api` and `valcache`. 