### PR TITLE
feat(core): implement gater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 dependencies = [
  "cargo-lock",
  "chrono",
@@ -1571,9 +1571,9 @@ checksum = "f7a879c84c21f354f13535f87ad119ac3be22ebb9097b552a0af6a78f86628c4"
 
 [[package]]
 name = "cargo-lock"
-version = "10.1.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06acb4f71407ba205a07cb453211e0e6a67b21904e47f6ba1f9589e38f2e454"
+checksum = "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
 dependencies = [
  "semver 1.0.28",
  "serde",
@@ -2208,7 +2208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2978,15 +2978,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -3439,7 +3438,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6118,7 +6117,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -7228,11 +7227,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7950,23 +7949,26 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap 2.14.0",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7976,20 +7978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -8014,10 +8002,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -9092,9 +9080,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/crates/consensus/src/qbft/component.rs
+++ b/crates/consensus/src/qbft/component.rs
@@ -21,6 +21,7 @@ use crate::{
 use pluto_core::{
     corepb::v1::{consensus as pbconsensus, core as pbcore, priority as pbpriority},
     deadline::{AddOutcome, DeadlinerHandle},
+    gater::DutyGaterFn,
     qbft,
     types::{Duty, DutyType},
 };
@@ -40,9 +41,6 @@ pub type Broadcaster = Arc<
         + Sync
         + 'static,
 >;
-
-/// Duty admission gate.
-pub type DutyGater = Arc<dyn Fn(&Duty) -> bool + Send + Sync + 'static>;
 
 /// Sink for completed sniffer instances.
 pub type SnifferSink = Arc<dyn Fn(pbconsensus::SniffedConsensusInstance) + Send + Sync + 'static>;
@@ -77,7 +75,7 @@ pub struct Config {
     /// Duty deadline scheduler.
     pub deadliner: DeadlinerHandle,
     /// Duty admission gate.
-    pub duty_gater: DutyGater,
+    pub duty_gater: DutyGaterFn,
     /// External message broadcaster.
     pub broadcaster: Broadcaster,
     /// Completed sniffer sink.
@@ -263,7 +261,7 @@ pub struct Consensus {
     local_peer_idx: i64,
     privkey: SecretKey,
     deadliner: DeadlinerHandle,
-    duty_gater: DutyGater,
+    duty_gater: DutyGaterFn,
     broadcaster: Broadcaster,
     sniffer: SnifferSink,
     timer_func: RoundTimerFunc,

--- a/crates/consensus/src/qbft/mod.rs
+++ b/crates/consensus/src/qbft/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod definition;
 pub(crate) mod runner;
 
 pub use component::{
-    BroadcastResult, Broadcaster, Config, Consensus, DutyGater, Error, Peer, Result, SnifferSink,
+    BroadcastResult, Broadcaster, Config, Consensus, Error, Peer, Result, SnifferSink,
     SubscriberResult,
 };
 pub use runner::{Error as RunnerError, Result as RunnerResult};

--- a/crates/core/src/gater.rs
+++ b/crates/core/src/gater.rs
@@ -11,9 +11,8 @@ use crate::{
     types::Duty,
 };
 
-/// Shared, callable duty-gating predicate. Structurally identical to
-/// `pluto_parsigex::DutyGater`, this is the value form that the wire components
-/// (parsigex, consensus) accept.
+/// Shared, callable duty-gating predicate: the value form that the wire
+/// components (parsigex, consensus) accept and invoke per duty.
 pub type DutyGaterFn = Arc<dyn Fn(&Duty) -> bool + Send + Sync + 'static>;
 
 /// Default number of epochs into the future for which duties are accepted.

--- a/crates/core/src/gater.rs
+++ b/crates/core/src/gater.rs
@@ -1,0 +1,312 @@
+//! Duty gater — rejects duties whose type is invalid or that are too far in the
+//! future.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use pluto_eth2api::{EthBeaconNodeApiClient, EthBeaconNodeApiClientError};
+
+use crate::{
+    clock::{ChronoClock, Clock},
+    types::Duty,
+};
+
+/// Shared, callable duty-gating predicate. Structurally identical to
+/// `pluto_parsigex::DutyGater`, this is the value form that the wire components
+/// (parsigex, consensus) accept.
+pub type DutyGaterFn = Arc<dyn Fn(&Duty) -> bool + Send + Sync + 'static>;
+
+/// Default number of epochs into the future for which duties are accepted.
+const DEFAULT_ALLOWED_FUTURE_EPOCHS: u64 = 2;
+
+/// Errors returned while constructing a [`DutyGater`].
+#[derive(Debug, thiserror::Error)]
+pub enum GaterError {
+    /// Failed to fetch beacon node configuration.
+    #[error("Failed to fetch beacon node configuration: {0}")]
+    BeaconNodeConfigError(#[from] EthBeaconNodeApiClientError),
+
+    /// The slot duration is not a positive whole number of milliseconds
+    /// (sub-millisecond, or too large to fit `u64`), so it cannot be used as a
+    /// divisor in the millisecond-resolution epoch arithmetic.
+    #[error("Slot duration is not a positive number of milliseconds")]
+    InvalidSlotDuration,
+}
+
+/// Result type for gater operations.
+pub type Result<T> = std::result::Result<T, GaterError>;
+
+/// Gates duties by type and recency.
+///
+/// [`DutyGater::allows`] returns `true` only when a duty may be processed. It
+/// rejects duties received from peers over the wire whose type is invalid or
+/// whose epoch is more than `allowed_future_epochs` beyond the current epoch.
+/// It does **not** reject duties in the past — that is the responsibility of
+/// the [`crate::deadline`] component.
+pub struct DutyGater {
+    genesis_time: DateTime<Utc>,
+    /// Slot duration in milliseconds. Always ≥ 1, enforced in
+    /// [`DutyGater::with_options`].
+    slot_duration_ms: u64,
+    /// Slots per epoch. Guaranteed non-zero by the `fetch_slots_config`
+    /// contract.
+    slots_per_epoch: u64,
+    allowed_future_epochs: u64,
+    clock: Box<dyn Clock>,
+}
+
+impl DutyGater {
+    /// Builds a gater from a beacon node client using production defaults: a
+    /// real wall clock and a `DEFAULT_ALLOWED_FUTURE_EPOCHS` future-epoch
+    /// budget.
+    pub async fn new(client: &EthBeaconNodeApiClient) -> Result<Self> {
+        Self::with_options(client, Box::new(ChronoClock), DEFAULT_ALLOWED_FUTURE_EPOCHS).await
+    }
+
+    /// Builds a gater with an injected clock and future-epoch budget. The
+    /// single fetch path shared with [`DutyGater::new`]; the overrides
+    /// exist for tests.
+    async fn with_options(
+        client: &EthBeaconNodeApiClient,
+        clock: Box<dyn Clock>,
+        allowed_future_epochs: u64,
+    ) -> Result<Self> {
+        let genesis_time = client.fetch_genesis_time().await?;
+        let (slot_duration, slots_per_epoch) = client.fetch_slots_config().await?;
+
+        // Work in whole milliseconds. `as_millis()` is u128 (SECONDS_PER_SLOT
+        // keeps it tiny); reject a zero (sub-millisecond) or overflowing value
+        // rather than divide by zero in `current_epoch`.
+        let slot_duration_ms = u64::try_from(slot_duration.as_millis())
+            .ok()
+            .filter(|&ms| ms != 0)
+            .ok_or(GaterError::InvalidSlotDuration)?;
+
+        Ok(Self {
+            genesis_time,
+            slot_duration_ms,
+            slots_per_epoch,
+            allowed_future_epochs,
+            clock,
+        })
+    }
+
+    /// Returns `true` if `duty` may be processed: its type is valid and its
+    /// epoch is no more than `allowed_future_epochs` beyond the current epoch.
+    #[must_use]
+    pub fn allows(&self, duty: &Duty) -> bool {
+        if !duty.duty_type.is_valid() {
+            return false;
+        }
+
+        let duty_epoch = duty
+            .slot
+            .inner()
+            .checked_div(self.slots_per_epoch)
+            .expect("slots_per_epoch is non-zero (fetch_slots_config contract)");
+
+        duty_epoch
+            <= self
+                .current_epoch()
+                .saturating_add(self.allowed_future_epochs)
+    }
+
+    /// Converts this gater into the shared callable [`DutyGaterFn`] consumed by
+    /// the wire components.
+    #[must_use]
+    pub fn into_fn(self) -> DutyGaterFn {
+        let gater = Arc::new(self);
+        Arc::new(move |duty: &Duty| gater.allows(duty))
+    }
+
+    /// Current epoch derived from the injected clock and genesis time.
+    fn current_epoch(&self) -> u64 {
+        let elapsed_ms = self
+            .clock
+            .now()
+            .signed_duration_since(self.genesis_time)
+            .num_milliseconds();
+
+        // Pre-genesis instants clamp to epoch 0: the gater is only built after
+        // genesis, so this path is unreachable in practice, and treating a
+        // negative elapsed time as a huge future slot would be nonsense.
+        let elapsed_ms = u64::try_from(elapsed_ms).unwrap_or(0);
+
+        let current_slot = elapsed_ms
+            .checked_div(self.slot_duration_ms)
+            .expect("slot_duration_ms >= 1 (enforced in with_options)");
+
+        current_slot
+            .checked_div(self.slots_per_epoch)
+            .expect("slots_per_epoch is non-zero (fetch_slots_config contract)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use chrono::{DateTime, Utc};
+    use pluto_testutil::BeaconMock;
+
+    use super::*;
+    use crate::types::{DutyType, SlotNumber};
+
+    /// A fixed clock returning `now` regardless of when it is called.
+    fn fixed_clock(now: DateTime<Utc>) -> Box<dyn Clock> {
+        Box::new(move || now)
+    }
+
+    /// Builds a gater from hand-set configuration and a fixed clock, for
+    /// non-async coverage that needs no beacon node.
+    fn gater(
+        genesis_time: DateTime<Utc>,
+        slot_duration_ms: u64,
+        slots_per_epoch: u64,
+        allowed_future_epochs: u64,
+        now: DateTime<Utc>,
+    ) -> DutyGater {
+        DutyGater {
+            genesis_time,
+            slot_duration_ms,
+            slots_per_epoch,
+            allowed_future_epochs,
+            clock: fixed_clock(now),
+        }
+    }
+
+    fn attester(slot: u64) -> Duty {
+        Duty::new_attester_duty(SlotNumber::new(slot))
+    }
+
+    fn duty_with_type(slot: u64, duty_type: DutyType) -> Duty {
+        Duty {
+            slot: SlotNumber::new(slot),
+            duty_type,
+        }
+    }
+
+    /// genesis == now (current epoch 0), 1s slots, 2 slots/epoch, 2 future
+    /// epochs allowed ⇒ slots 0-5 accepted.
+    #[tokio::test]
+    async fn duty_gater() {
+        // Genesis round-trips through the beacon API as whole seconds, so pin
+        // `now` to a whole second to make the injected clock equal genesis.
+        let now = DateTime::from_timestamp(Utc::now().timestamp(), 0).expect("valid timestamp");
+
+        let bmock = BeaconMock::builder()
+            .genesis_time(now)
+            .slot_duration(Duration::from_secs(1))
+            .slots_per_epoch(2)
+            .build()
+            .await
+            .expect("build beacon mock");
+
+        let gater = DutyGater::with_options(bmock.client(), fixed_clock(now), 2)
+            .await
+            .expect("build gater");
+
+        // Allowed: slots 0-5 (epochs 0, 1, 2 ≤ budget 2).
+        for slot in 0..=5 {
+            assert!(
+                gater.allows(&attester(slot)),
+                "slot {slot} should be allowed"
+            );
+        }
+
+        // Disallowed: slot 6 onwards (epoch 3+).
+        for slot in [6, 7, 1000] {
+            assert!(
+                !gater.allows(&attester(slot)),
+                "slot {slot} should be disallowed"
+            );
+        }
+
+        // Invalid duty types are rejected regardless of slot.
+        assert!(!gater.allows(&duty_with_type(0, DutyType::Unknown)));
+        assert!(!gater.allows(&duty_with_type(
+            1,
+            DutyType::DutySentinel(Box::new(DutyType::Attester))
+        )));
+    }
+
+    /// Smoke test of the public `new` entrypoint (real `ChronoClock`, default
+    /// budget) against a mainnet-like 12s/32-slot config. Genesis is pinned to
+    /// ~now, so `current_epoch` stays 0 for the whole test (epochs are 384s
+    /// long) and the default future-epoch budget of 2 is locked in: slot 96
+    /// (epoch 3) would only be allowed if the default were 3.
+    #[tokio::test]
+    async fn new_defaults() {
+        let now = DateTime::from_timestamp(Utc::now().timestamp(), 0).expect("valid timestamp");
+
+        let bmock = BeaconMock::builder()
+            .genesis_time(now)
+            .slot_duration(Duration::from_secs(12))
+            .slots_per_epoch(32)
+            .build()
+            .await
+            .expect("build beacon mock");
+
+        let gater = DutyGater::new(bmock.client()).await.expect("build gater");
+
+        assert!(gater.allows(&attester(0))); // current epoch
+        assert!(gater.allows(&attester(95))); // epoch 2 (= budget)
+        assert!(!gater.allows(&attester(96))); // epoch 3 (> budget)
+    }
+
+    /// Non-async coverage of the epoch boundary with a non-zero current epoch
+    /// (the async test above only exercises current epoch 0).
+    #[test]
+    fn epoch_boundary() {
+        let genesis = DateTime::from_timestamp(1_600_000_000, 0).expect("valid timestamp");
+        // 100s after genesis at 1s slots ⇒ slot 100 ⇒ epoch 3 (32 slots/epoch).
+        let now = DateTime::from_timestamp(1_600_000_100, 0).expect("valid timestamp");
+        // Budget = current epoch 3 + 2 = 5 ⇒ duty epoch ≤ 5 (slot ≤ 191) allowed.
+        let gater = gater(genesis, 1_000, 32, 2, now);
+
+        assert!(gater.allows(&attester(96))); // current epoch (3)
+        assert!(gater.allows(&attester(128))); // N+1
+        assert!(gater.allows(&attester(160))); // N+2 start
+        assert!(gater.allows(&attester(191))); // N+2 end
+        assert!(!gater.allows(&attester(192))); // N+3
+        assert!(!gater.allows(&attester(10_000)));
+    }
+
+    /// Pre-genesis instants clamp to epoch 0.
+    #[test]
+    fn pre_genesis_clamps_to_epoch_zero() {
+        let genesis = DateTime::from_timestamp(1_600_000_100, 0).expect("valid timestamp");
+        let now = DateTime::from_timestamp(1_600_000_000, 0).expect("valid timestamp");
+        // Budget = epoch 0 + 2 = 2 ⇒ slot ≤ 95 (epoch ≤ 2) allowed at 32 slots/epoch.
+        let gater = gater(genesis, 1_000, 32, 2, now);
+
+        assert!(gater.allows(&attester(0)));
+        assert!(gater.allows(&attester(95))); // epoch 2
+        assert!(!gater.allows(&attester(96))); // epoch 3
+    }
+
+    /// `into_fn` yields a callable predicate equivalent to `allows`, usable
+    /// where a `DutyGaterFn` (e.g. `pluto_parsigex::DutyGater`) is expected.
+    #[test]
+    fn into_fn_matches_allows() {
+        let genesis = DateTime::from_timestamp(1_600_000_000, 0).expect("valid timestamp");
+        let now = DateTime::from_timestamp(1_600_000_100, 0).expect("valid timestamp");
+        let gater_fn: DutyGaterFn = gater(genesis, 1_000, 32, 2, now).into_fn();
+
+        assert!(gater_fn(&attester(191)));
+        assert!(!gater_fn(&attester(192)));
+        assert!(!gater_fn(&duty_with_type(0, DutyType::Unknown)));
+    }
+
+    #[test]
+    fn invalid_type_rejected() {
+        let genesis = DateTime::from_timestamp(1_600_000_000, 0).expect("valid timestamp");
+        let gater = gater(genesis, 1_000, 32, 2, genesis);
+
+        assert!(!gater.allows(&duty_with_type(0, DutyType::Unknown)));
+        assert!(!gater.allows(&duty_with_type(
+            0,
+            DutyType::DutySentinel(Box::new(DutyType::Attester))
+        )));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -26,6 +26,10 @@ pub mod deadline;
 /// Clock abstraction over the current time.
 pub mod clock;
 
+/// Duty gater — rejects duties whose type is invalid or that are too far in the
+/// future.
+pub mod gater;
+
 /// parsigdb
 pub mod parsigdb;
 

--- a/crates/dkg/src/exchanger.rs
+++ b/crates/dkg/src/exchanger.rs
@@ -330,7 +330,9 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
-    use super::{Exchanger, SIG_DEPOSIT_DATA, SIG_LOCK, SIG_VALIDATOR_REG, SigTypeStore};
+    use super::{
+        DutyGaterFn, Exchanger, SIG_DEPOSIT_DATA, SIG_LOCK, SIG_VALIDATOR_REG, SigTypeStore,
+    };
 
     fn available_tcp_port() -> anyhow::Result<u16> {
         let listener = TcpListener::bind("127.0.0.1:0")?;

--- a/crates/dkg/src/exchanger.rs
+++ b/crates/dkg/src/exchanger.rs
@@ -49,6 +49,7 @@ use tracing::warn;
 
 use pluto_core::{
     deadline::{DeadlinerTask, NeverExpiringCalculator},
+    gater::DutyGaterFn,
     parsigdb::memory::{
         InternalSubscriberError, MemDB, MemDBError, internal_subscriber, threshold_subscriber,
     },
@@ -100,8 +101,6 @@ impl Default for DataByPubkey {
         }
     }
 }
-
-type DutyGaterFn = Arc<dyn Fn(&Duty) -> bool + Send + Sync + 'static>;
 
 /// Errors returned by exchanger operations.
 #[derive(Debug, thiserror::Error)]
@@ -375,7 +374,7 @@ mod tests {
         let p2p_context = P2PContext::new(peer_ids.to_vec());
         let verifier: pluto_parsigex::Verifier =
             Arc::new(|_duty, _pk, _psig| Box::pin(async { Ok(()) }));
-        let duty_gater: pluto_parsigex::DutyGater =
+        let duty_gater: DutyGaterFn =
             Arc::new(|duty: &pluto_core::types::Duty| duty.duty_type == DutyType::Signature);
 
         ParsexBehaviour::new(ParsexConfig::new(
@@ -515,7 +514,7 @@ mod tests {
 
             let verifier: pluto_parsigex::Verifier =
                 Arc::new(|_duty, _pk, _psig| Box::pin(async { Ok(()) }));
-            let duty_gater: pluto_parsigex::DutyGater =
+            let duty_gater: DutyGaterFn =
                 Arc::new(|duty: &pluto_core::types::Duty| duty.duty_type == DutyType::Signature);
 
             let config = ParsexConfig::new(peer_ids[i], p2p_context.clone(), verifier, duty_gater);

--- a/crates/parsigex/examples/parsigex.rs
+++ b/crates/parsigex/examples/parsigex.rs
@@ -68,6 +68,7 @@ use libp2p::{
 };
 use pluto_cluster::lock::Lock;
 use pluto_core::{
+    gater::DutyGaterFn,
     signeddata::SignedRandao,
     types::{Duty, DutyType, ParSignedDataSet, PubKey, SlotNumber},
 };
@@ -81,7 +82,7 @@ use pluto_p2p::{
     peer::peer_id_from_key,
     relay::{RelayManager, RelayManagerEvent},
 };
-use pluto_parsigex::{self as parsigex, DutyGater, Event, Handle, Verifier};
+use pluto_parsigex::{self as parsigex, Event, Handle, Verifier};
 use pluto_tracing::TracingConfig;
 use tokio::fs;
 use tokio_util::sync::CancellationToken;
@@ -247,7 +248,7 @@ async fn main() -> Result<()> {
 
     let verifier: Verifier =
         std::sync::Arc::new(|_duty, _pubkey, _data| Box::pin(async { Ok(()) }));
-    let duty_gater: DutyGater = std::sync::Arc::new(|duty| duty.duty_type != DutyType::Unknown);
+    let duty_gater: DutyGaterFn = std::sync::Arc::new(|duty| duty.duty_type != DutyType::Unknown);
     let handle_slot = std::sync::Arc::new(tokio::sync::Mutex::new(1_u64));
 
     let p2p_config = P2PConfig {

--- a/crates/parsigex/src/behaviour.rs
+++ b/crates/parsigex/src/behaviour.rs
@@ -22,7 +22,7 @@ use libp2p::{
 };
 use tokio::sync::{RwLock, mpsc, oneshot};
 
-use pluto_core::types::{Duty, ParSignedData, ParSignedDataSet, PubKey};
+use pluto_core::{gater::DutyGaterFn, types::{Duty, ParSignedData, ParSignedDataSet, PubKey}};
 use pluto_p2p::p2p_context::P2PContext;
 
 use super::{Handler, encode_message};
@@ -38,9 +38,6 @@ pub type VerifyFuture =
 /// Verifier callback type.
 pub type Verifier =
     Arc<dyn Fn(Duty, PubKey, ParSignedData) -> VerifyFuture + Send + Sync + 'static>;
-
-/// Duty gate callback type.
-pub type DutyGater = Arc<dyn Fn(&Duty) -> bool + Send + Sync + 'static>;
 
 /// Future returned by received subscriber callbacks.
 pub type ReceivedSubFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
@@ -187,7 +184,7 @@ pub struct Config {
     peer_id: PeerId,
     p2p_context: P2PContext,
     verifier: Verifier,
-    duty_gater: DutyGater,
+    duty_gater: DutyGaterFn,
     timeout: Duration,
 }
 
@@ -197,7 +194,7 @@ impl Config {
         peer_id: PeerId,
         p2p_context: P2PContext,
         verifier: Verifier,
-        duty_gater: DutyGater,
+        duty_gater: DutyGaterFn,
     ) -> Self {
         Self {
             peer_id,

--- a/crates/parsigex/src/behaviour.rs
+++ b/crates/parsigex/src/behaviour.rs
@@ -22,7 +22,10 @@ use libp2p::{
 };
 use tokio::sync::{RwLock, mpsc, oneshot};
 
-use pluto_core::{gater::DutyGaterFn, types::{Duty, ParSignedData, ParSignedDataSet, PubKey}};
+use pluto_core::{
+    gater::DutyGaterFn,
+    types::{Duty, ParSignedData, ParSignedDataSet, PubKey},
+};
 use pluto_p2p::p2p_context::P2PContext;
 
 use super::{Handler, encode_message};

--- a/crates/parsigex/src/handler.rs
+++ b/crates/parsigex/src/handler.rs
@@ -19,9 +19,9 @@ use libp2p::{
 };
 use tokio::time::timeout;
 
-use pluto_core::types::{Duty, ParSignedDataSet};
+use pluto_core::{gater::DutyGaterFn, types::{Duty, ParSignedDataSet}};
 
-use super::{DutyGater, PROTOCOL_NAME, Verifier, protocol};
+use super::{PROTOCOL_NAME, Verifier, protocol};
 use crate::error::Failure;
 
 /// Command sent from the behaviour to a handler.
@@ -78,14 +78,14 @@ type ActiveFuture = BoxFuture<'static, Option<FromHandler>>;
 pub struct Handler {
     timeout: Duration,
     verifier: Verifier,
-    duty_gater: DutyGater,
+    duty_gater: DutyGaterFn,
     pending_open: VecDeque<PendingOpen>,
     active_futures: FuturesUnordered<ActiveFuture>,
 }
 
 impl Handler {
     /// Creates a new handler for one connection.
-    pub fn new(timeout: Duration, verifier: Verifier, duty_gater: DutyGater) -> Self {
+    pub fn new(timeout: Duration, verifier: Verifier, duty_gater: DutyGaterFn) -> Self {
         Self {
             timeout,
             verifier,
@@ -247,7 +247,7 @@ impl ConnectionHandler for Handler {
 async fn do_recv(
     mut stream: libp2p::swarm::Stream,
     verifier: Verifier,
-    duty_gater: DutyGater,
+    duty_gater: DutyGaterFn,
 ) -> Result<(Duty, ParSignedDataSet), Failure> {
     let bytes = protocol::recv_message(&mut stream)
         .await

--- a/crates/parsigex/src/handler.rs
+++ b/crates/parsigex/src/handler.rs
@@ -19,7 +19,10 @@ use libp2p::{
 };
 use tokio::time::timeout;
 
-use pluto_core::{gater::DutyGaterFn, types::{Duty, ParSignedDataSet}};
+use pluto_core::{
+    gater::DutyGaterFn,
+    types::{Duty, ParSignedDataSet},
+};
 
 use super::{PROTOCOL_NAME, Verifier, protocol};
 use crate::error::Failure;

--- a/crates/parsigex/src/lib.rs
+++ b/crates/parsigex/src/lib.rs
@@ -6,8 +6,7 @@ mod handler;
 mod protocol;
 
 pub use behaviour::{
-    Behaviour, Config, Event, Handle, ReceivedSub, ReceivedSubFuture, Verifier,
-    received_subscriber,
+    Behaviour, Config, Event, Handle, ReceivedSub, ReceivedSubFuture, Verifier, received_subscriber,
 };
 pub use error::{Error, Failure, Result, VerifyError};
 pub use handler::Handler;

--- a/crates/parsigex/src/lib.rs
+++ b/crates/parsigex/src/lib.rs
@@ -6,7 +6,7 @@ mod handler;
 mod protocol;
 
 pub use behaviour::{
-    Behaviour, Config, DutyGater, Event, Handle, ReceivedSub, ReceivedSubFuture, Verifier,
+    Behaviour, Config, Event, Handle, ReceivedSub, ReceivedSubFuture, Verifier,
     received_subscriber,
 };
 pub use error::{Error, Failure, Result, VerifyError};


### PR DESCRIPTION
Fix https://github.com/NethermindEth/pluto/issues/399

Ports the core/gater component: a `DutyGater` that rejects duties arriving from peers whose type is invalid or whose epoch is too far in the future.

  - crates/core/src/gater.rs — `DutyGater::new(client)` fetches genesis time + slot config from the beacon node and builds the gater (default budget: 2 future epochs); `allows(&duty) -> bool` is the predicate, and `into_fn()` yields the shared `DutyGaterFn (Arc<dyn Fn(&Duty) -> bool + Send + Sync>)` that the wire components consume.
  - Canonical type — `pluto_core::gater::DutyGaterFn` is now the single source of truth; parsigex, consensus, and dkg use it directly instead of each redefining an identical alias.