### PR TITLE
refactor: remove featureset::GLOBAL_STATE

### DIFF
--- a/crates/consensus/examples/qbft.rs
+++ b/crates/consensus/examples/qbft.rs
@@ -94,6 +94,7 @@ use pluto_core::{
     types::{Duty, DutyType, SlotNumber},
 };
 use pluto_eth2util::enr::Record;
+use pluto_featureset::FeatureSet;
 use pluto_p2p::{
     behaviours::pluto::PlutoBehaviourEvent,
     bootnode,
@@ -597,6 +598,8 @@ fn build_consensus(
         DemoDeadline { timeout },
     );
     let local_node = fixture.local_index;
+    let feature_set = Arc::new(FeatureSet::new());
+    let timer_feature_set = feature_set.clone();
     let component = Arc::new(qbft::Consensus::new(qbft::Config {
         peers: fixture.consensus_peers.clone(),
         local_peer_idx: i64::try_from(fixture.local_index)?,
@@ -613,9 +616,13 @@ fn build_consensus(
             );
         }),
         compare_attestations: false,
-        timer_func: Box::new(|duty| {
-            Box::new(IncreasingRoundTimer::with_duty(duty)) as Box<dyn RoundTimer>
+        timer_func: Box::new(move |duty| {
+            Box::new(IncreasingRoundTimer::with_duty(
+                duty,
+                timer_feature_set.clone(),
+            )) as Box<dyn RoundTimer>
         }),
+        feature_set,
     })?);
     component.subscribe(move |decision_duty, value| {
         let _ = decision_tx.send(Decision {

--- a/crates/consensus/src/controller.rs
+++ b/crates/consensus/src/controller.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use k256::SecretKey;
 use pluto_core::{deadline::DeadlinerHandle, gater::DutyGaterFn, types::Duty};
+use pluto_featureset::FeatureSet;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -51,6 +52,8 @@ pub struct Config {
     pub compare_attestations: bool,
     /// Round timer factory.
     pub timer_func: RoundTimerFunc,
+    /// Injected feature set, resolved once at construction.
+    pub feature_set: Arc<FeatureSet>,
 }
 
 /// Controls the active consensus protocol implementation.
@@ -73,6 +76,7 @@ impl ConsensusController {
             sniffer: config.debugger.sniffer(),
             compare_attestations: config.compare_attestations,
             timer_func: config.timer_func,
+            feature_set: config.feature_set,
         })?);
         let default_consensus: Arc<dyn Consensus> = qbft;
 
@@ -161,6 +165,7 @@ mod tests {
         let (deadliner, expired_rx) =
             DeadlinerTask::start(ct, "controller-test", NeverExpiringCalculator);
 
+        let fs = Arc::new(FeatureSet::new());
         Config {
             peers: peers(),
             local_peer_idx: 0,
@@ -171,7 +176,8 @@ mod tests {
             broadcaster: Arc::new(|_, _| Box::pin(async { Ok(()) })),
             debugger: Debugger::new(),
             compare_attestations: false,
-            timer_func: get_round_timer_func(),
+            timer_func: get_round_timer_func(fs.clone()),
+            feature_set: fs,
         }
     }
 

--- a/crates/consensus/src/qbft/component.rs
+++ b/crates/consensus/src/qbft/component.rs
@@ -25,6 +25,7 @@ use pluto_core::{
     qbft,
     types::{Duty, DutyType},
 };
+use pluto_featureset::{Feature, FeatureSet};
 
 use super::{
     msg::{self, ValueMap},
@@ -86,6 +87,8 @@ pub struct Config {
     pub compare_attestations: bool,
     /// Round timer factory.
     pub timer_func: RoundTimerFunc,
+    /// Injected feature set, resolved once at construction.
+    pub feature_set: Arc<FeatureSet>,
 }
 
 /// Decoded consensus value supported by this component.
@@ -269,6 +272,7 @@ pub struct Consensus {
     sniffer: SnifferSink,
     timer_func: RoundTimerFunc,
     compare_attestations: bool,
+    feature_set: Arc<FeatureSet>,
     subscribers: SubscriberSet,
     instances: Arc<Mutex<HashMap<Duty, Arc<InstanceIo<msg::Msg>>>>>,
 }
@@ -304,6 +308,7 @@ impl Consensus {
             sniffer: config.sniffer,
             timer_func: config.timer_func,
             compare_attestations: config.compare_attestations,
+            feature_set: config.feature_set,
             subscribers: SubscriberSet::default(),
             instances: Arc::new(Mutex::default()),
         })
@@ -312,6 +317,11 @@ impl Consensus {
     /// Returns the QBFT v2 protocol ID.
     pub fn protocol_id(&self) -> &'static str {
         QBFT_V2_PROTOCOL_ID
+    }
+
+    /// Returns whether `feature` is enabled for this consensus instance.
+    pub(crate) fn feature_enabled(&self, feature: Feature) -> bool {
+        self.feature_set.enabled(feature)
     }
 
     /// Registers a callback for decided unsigned duty data.
@@ -1289,10 +1299,23 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn consensus(local_peer_idx: i64, duty_allowed: bool) -> Consensus {
+        consensus_with_feature_set(
+            local_peer_idx,
+            duty_allowed,
+            Arc::new(pluto_featureset::FeatureSet::new()),
+        )
+    }
+
+    pub(crate) fn consensus_with_feature_set(
+        local_peer_idx: i64,
+        duty_allowed: bool,
+        feature_set: Arc<pluto_featureset::FeatureSet>,
+    ) -> Consensus {
         Consensus::new(Config {
             peers: peers(),
             local_peer_idx,
             duty_gater: Arc::new(move |_| duty_allowed),
+            feature_set,
             ..config_base(false)
         })
         .unwrap()
@@ -1310,6 +1333,7 @@ pub(crate) mod tests {
             DeadlinerTask::start(cancel, "qbft-test", FutureCalculator)
         };
 
+        let fs = Arc::new(pluto_featureset::FeatureSet::new());
         Config {
             peers: vec![],
             local_peer_idx: 0,
@@ -1320,7 +1344,8 @@ pub(crate) mod tests {
             broadcaster: Arc::new(|_, _| Box::pin(async { Ok(()) })),
             sniffer: Arc::new(|_| {}),
             compare_attestations: false,
-            timer_func: get_round_timer_func(),
+            timer_func: get_round_timer_func(fs.clone()),
+            feature_set: fs,
         }
     }
 

--- a/crates/consensus/src/qbft/mod.rs
+++ b/crates/consensus/src/qbft/mod.rs
@@ -20,12 +20,6 @@ pub(crate) mod sniffer;
 pub(crate) mod transport;
 
 #[cfg(test)]
-// QBFT tests override pluto_featureset::GLOBAL_STATE to exercise feature-gated
-// paths. Since that state is process-global, those tests must serialize their
-// mutations until the feature set is threaded as an explicit dependency.
-pub(crate) static FEATURESET_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-#[cfg(test)]
 mod qbft_run_test;
 #[cfg(test)]
 mod strategy_sim_test;

--- a/crates/consensus/src/qbft/qbft_run_test.rs
+++ b/crates/consensus/src/qbft/qbft_run_test.rs
@@ -201,7 +201,6 @@ async fn qbft_priority_consensus() {
 
 #[tokio::test]
 async fn qbft_consensus_participate_then_late_propose() {
-    let _featureset_guard = super::FEATURESET_TEST_LOCK.lock().await;
     let threshold = 4;
     let (sniffed_tx, _sniffed_rx) = mpsc::unbounded_channel();
     let active_nodes = in_memory_network(threshold, threshold, false, None, sniffed_tx);
@@ -741,7 +740,9 @@ fn in_memory_network(
                 compare_attestations,
                 timer_func: match round_timeout {
                     Some(timeout) => short_timer_func(timeout),
-                    None => crate::timer::get_round_timer_func(),
+                    None => crate::timer::get_round_timer_func(Arc::new(
+                        pluto_featureset::FeatureSet::new(),
+                    )),
                 },
                 sniffer: {
                     let sniffed_tx = sniffed_tx.clone();

--- a/crates/consensus/src/qbft/runner.rs
+++ b/crates/consensus/src/qbft/runner.rs
@@ -178,11 +178,7 @@ pub(crate) async fn participate(
         return Ok(());
     }
 
-    if !pluto_featureset::GLOBAL_STATE
-        .read()
-        .expect("global feature set lock poisoned")
-        .enabled(pluto_featureset::Feature::ConsensusParticipate)
-    {
+    if !consensus.feature_enabled(pluto_featureset::Feature::ConsensusParticipate) {
         return Ok(());
     }
 
@@ -536,12 +532,11 @@ fn transport_broadcaster(broadcaster: super::component::Broadcaster) -> transpor
 #[cfg(test)]
 mod tests {
     use std::{
-        mem,
         sync::{Arc, Mutex},
         time::Duration,
     };
 
-    use pluto_featureset::{Config as FeatureConfig, Feature, FeatureSet, GLOBAL_STATE, Status};
+    use pluto_featureset::{Config as FeatureConfig, Feature, FeatureSet};
     use prost::bytes::Bytes;
     use prost_types::Any;
     use tokio::sync::mpsc;
@@ -660,13 +655,15 @@ mod tests {
 
     #[tokio::test]
     async fn participate_skips_when_feature_disabled() {
-        let _featureset_guard = crate::qbft::FEATURESET_TEST_LOCK.lock().await;
-        let consensus = component::tests::consensus(0, true);
+        let feature_set = Arc::new(
+            FeatureSet::from_config(FeatureConfig {
+                disabled: vec![Feature::ConsensusParticipate],
+                ..FeatureConfig::default()
+            })
+            .expect("test featureset is valid"),
+        );
+        let consensus = component::tests::consensus_with_feature_set(0, true, feature_set);
         let duty = component::tests::duty();
-        let _guard = FeatureSetGuard::new(FeatureConfig {
-            disabled: vec![Feature::ConsensusParticipate],
-            ..FeatureConfig::default()
-        });
 
         participate(&consensus, duty.clone(), &CancellationToken::new())
             .await
@@ -676,7 +673,6 @@ mod tests {
 
     #[tokio::test]
     async fn participate_rejects_duplicate_entrypoint() {
-        let _featureset_guard = crate::qbft::FEATURESET_TEST_LOCK.lock().await;
         let consensus = component::tests::consensus(0, true);
         let duty = component::tests::duty();
         let inst = consensus.get_instance_io(duty.clone());
@@ -869,38 +865,5 @@ mod tests {
             Bytes::from(format!("unsigned-{seed}")),
         );
         pbcore::UnsignedDataSet { set }
-    }
-
-    struct FeatureSetGuard {
-        previous: Option<FeatureSet>,
-    }
-
-    impl FeatureSetGuard {
-        fn new(config: FeatureConfig) -> Self {
-            let replacement = FeatureSet::from_config(FeatureConfig {
-                min_status: Status::Stable,
-                ..config
-            })
-            .expect("test featureset is valid");
-            let mut global = GLOBAL_STATE
-                .write()
-                .expect("global feature set lock poisoned");
-            let previous = mem::replace(&mut *global, replacement);
-            drop(global);
-
-            Self {
-                previous: Some(previous),
-            }
-        }
-    }
-
-    impl Drop for FeatureSetGuard {
-        fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
-                *GLOBAL_STATE
-                    .write()
-                    .expect("global feature set lock poisoned") = previous;
-            }
-        }
     }
 }

--- a/crates/consensus/src/timer.rs
+++ b/crates/consensus/src/timer.rs
@@ -26,11 +26,11 @@ use std::{
     collections::{HashMap, hash_map::Entry},
     future::Future,
     pin::Pin,
-    sync::Mutex,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
-use pluto_featureset::{Feature, GLOBAL_STATE};
+use pluto_featureset::{Feature, FeatureSet};
 use tokio::time::{Instant, sleep_until};
 
 use pluto_core::types::{Duty, DutyType};
@@ -129,17 +129,24 @@ pub trait RoundTimer: Send + Sync {
 #[derive(Debug, Clone, Default)]
 pub struct IncreasingRoundTimer {
     duty: Option<Duty>,
+    feature_set: Arc<FeatureSet>,
 }
 
 impl IncreasingRoundTimer {
     /// Creates an increasing round timer.
     pub fn new() -> Self {
-        Self { duty: None }
+        Self {
+            duty: None,
+            feature_set: Arc::new(FeatureSet::new()),
+        }
     }
 
     /// Creates an increasing round timer for a duty.
-    pub fn with_duty(duty: Duty) -> Self {
-        Self { duty: Some(duty) }
+    pub fn with_duty(duty: Duty, feature_set: Arc<FeatureSet>) -> Self {
+        Self {
+            duty: Some(duty),
+            feature_set,
+        }
     }
 }
 
@@ -149,7 +156,8 @@ impl RoundTimer for IncreasingRoundTimer {
     }
 
     fn timer(&self, round: i64) -> Result<RoundTimerFuture> {
-        let timeout = match proposal_timeout_duration(self.duty.as_ref(), round) {
+        let timeout = match proposal_timeout_duration(self.duty.as_ref(), round, &self.feature_set)
+        {
             Some(timeout) => timeout,
             None => increasing_round_timeout(round)?,
         };
@@ -179,6 +187,7 @@ impl RoundTimer for IncreasingRoundTimer {
 #[derive(Debug, Default)]
 pub struct EagerDoubleLinearRoundTimer {
     duty: Option<Duty>,
+    feature_set: Arc<FeatureSet>,
     first_deadlines: Mutex<HashMap<i64, Instant>>,
 }
 
@@ -187,14 +196,16 @@ impl EagerDoubleLinearRoundTimer {
     pub fn new() -> Self {
         Self {
             duty: None,
+            feature_set: Arc::new(FeatureSet::new()),
             first_deadlines: Mutex::new(HashMap::new()),
         }
     }
 
     /// Creates an eager double linear round timer for a duty.
-    pub fn with_duty(duty: Duty) -> Self {
+    pub fn with_duty(duty: Duty, feature_set: Arc<FeatureSet>) -> Self {
         Self {
             duty: Some(duty),
+            feature_set,
             first_deadlines: Mutex::new(HashMap::new()),
         }
     }
@@ -206,7 +217,8 @@ impl RoundTimer for EagerDoubleLinearRoundTimer {
     }
 
     fn timer(&self, round: i64) -> Result<RoundTimerFuture> {
-        let timeout = match proposal_timeout_duration(self.duty.as_ref(), round) {
+        let timeout = match proposal_timeout_duration(self.duty.as_ref(), round, &self.feature_set)
+        {
             Some(timeout) => timeout,
             None => linear_round_timeout(round)?,
         };
@@ -240,17 +252,24 @@ impl RoundTimer for EagerDoubleLinearRoundTimer {
 #[derive(Debug, Clone, Default)]
 pub struct LinearRoundTimer {
     duty: Option<Duty>,
+    feature_set: Arc<FeatureSet>,
 }
 
 impl LinearRoundTimer {
     /// Creates a linear round timer.
     pub fn new() -> Self {
-        Self { duty: None }
+        Self {
+            duty: None,
+            feature_set: Arc::new(FeatureSet::new()),
+        }
     }
 
     /// Creates a linear round timer for a duty.
-    pub fn with_duty(duty: Duty) -> Self {
-        Self { duty: Some(duty) }
+    pub fn with_duty(duty: Duty, feature_set: Arc<FeatureSet>) -> Self {
+        Self {
+            duty: Some(duty),
+            feature_set,
+        }
     }
 }
 
@@ -260,7 +279,8 @@ impl RoundTimer for LinearRoundTimer {
     }
 
     fn timer(&self, round: i64) -> Result<RoundTimerFuture> {
-        let timeout = match proposal_timeout_duration(self.duty.as_ref(), round) {
+        let timeout = match proposal_timeout_duration(self.duty.as_ref(), round, &self.feature_set)
+        {
             Some(timeout) => timeout,
             None if round == 1 => Duration::from_secs(1),
             None => linear_subsequent_round_timeout(round)?,
@@ -271,32 +291,35 @@ impl RoundTimer for LinearRoundTimer {
 }
 
 /// Returns a timer function based on the enabled features.
-pub fn get_round_timer_func() -> RoundTimerFunc {
-    if feature_enabled(Feature::Linear) {
-        return Box::new(|duty| {
+///
+/// The injected `feature_set` is cloned into each built timer, which reads
+/// `ProposalTimeout` from it per round.
+pub fn get_round_timer_func(feature_set: Arc<FeatureSet>) -> RoundTimerFunc {
+    if feature_set.enabled(Feature::Linear) {
+        return Box::new(move |duty| {
             if is_proposer(&duty) {
-                Box::new(LinearRoundTimer::with_duty(duty))
-            } else if feature_enabled(Feature::EagerDoubleLinear) {
-                Box::new(EagerDoubleLinearRoundTimer::with_duty(duty))
+                Box::new(LinearRoundTimer::with_duty(duty, feature_set.clone()))
+            } else if feature_set.enabled(Feature::EagerDoubleLinear) {
+                Box::new(EagerDoubleLinearRoundTimer::with_duty(
+                    duty,
+                    feature_set.clone(),
+                ))
             } else {
-                Box::new(IncreasingRoundTimer::with_duty(duty))
+                Box::new(IncreasingRoundTimer::with_duty(duty, feature_set.clone()))
             }
         });
     }
 
-    if feature_enabled(Feature::EagerDoubleLinear) {
-        Box::new(|duty| Box::new(EagerDoubleLinearRoundTimer::with_duty(duty)))
+    if feature_set.enabled(Feature::EagerDoubleLinear) {
+        Box::new(move |duty| {
+            Box::new(EagerDoubleLinearRoundTimer::with_duty(
+                duty,
+                feature_set.clone(),
+            ))
+        })
     } else {
-        Box::new(|duty| Box::new(IncreasingRoundTimer::with_duty(duty)))
+        Box::new(move |duty| Box::new(IncreasingRoundTimer::with_duty(duty, feature_set.clone())))
     }
-}
-
-/// Returns whether a consensus timer feature is enabled globally.
-fn feature_enabled(feature: Feature) -> bool {
-    GLOBAL_STATE
-        .read()
-        .expect("global feature set lock poisoned")
-        .enabled(feature)
 }
 
 /// Returns true for duties that use the proposer-specific timer path.
@@ -304,9 +327,15 @@ fn is_proposer(duty: &Duty) -> bool {
     matches!(&duty.duty_type, DutyType::Proposer)
 }
 
-/// Returns proposer round-one override duration when enabled.
-fn proposal_timeout_duration(duty: Option<&Duty>, round: i64) -> Option<Duration> {
-    if round == 1 && duty.is_some_and(is_proposer) && feature_enabled(Feature::ProposalTimeout) {
+/// Returns the proposer round-one override duration, when `ProposalTimeout` is
+/// enabled and the duty is a proposer in round one.
+fn proposal_timeout_duration(
+    duty: Option<&Duty>,
+    round: i64,
+    feature_set: &FeatureSet,
+) -> Option<Duration> {
+    if round == 1 && duty.is_some_and(is_proposer) && feature_set.enabled(Feature::ProposalTimeout)
+    {
         Some(PROPOSAL_TIMEOUT)
     } else {
         None
@@ -390,11 +419,7 @@ fn checked_deadline(start: Instant, timeout: Duration, round: i64) -> Result<Ins
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        mem,
-        sync::{Mutex as StdMutex, MutexGuard},
-        time::Duration,
-    };
+    use std::{sync::Arc, time::Duration};
 
     use pluto_featureset::{Config, FeatureSet};
     use test_case::test_case;
@@ -402,9 +427,6 @@ mod tests {
 
     use super::*;
     use pluto_core::types::SlotNumber;
-
-    // Feature state is process-global.
-    static FEATURESET_TEST_LOCK: StdMutex<()> = StdMutex::new(());
 
     #[test_case(TimerType::Increasing, "inc" ; "increasing")]
     #[test_case(TimerType::EagerDoubleLinear, "eager_dlinear" ; "eager_double_linear")]
@@ -499,55 +521,42 @@ mod tests {
         let attester = Duty::new_attester_duty(SlotNumber::from(0));
         let proposer = Duty::new_proposer_duty(SlotNumber::from(0));
 
-        with_featureset(Config::default(), || {
-            let timer_func = get_round_timer_func();
-            assert_eq!(
-                TimerType::EagerDoubleLinear,
-                timer_func(attester.clone()).timer_type()
-            );
-        });
-
-        with_featureset(
-            features_config(vec![], vec![Feature::EagerDoubleLinear]),
-            || {
-                let timer_func = get_round_timer_func();
-                assert_eq!(
-                    TimerType::Increasing,
-                    timer_func(attester.clone()).timer_type()
-                );
-            },
+        let fs = FeatureSet::new();
+        let timer_func = get_round_timer_func(Arc::new(fs));
+        assert_eq!(
+            TimerType::EagerDoubleLinear,
+            timer_func(attester.clone()).timer_type()
         );
 
-        with_featureset(
-            features_config(vec![Feature::Linear], vec![Feature::EagerDoubleLinear]),
-            || {
-                let timer_func = get_round_timer_func();
-                assert_eq!(
-                    TimerType::Increasing,
-                    timer_func(attester.clone()).timer_type()
-                );
-            },
+        let fs = featureset(vec![], vec![Feature::EagerDoubleLinear]);
+        let timer_func = get_round_timer_func(Arc::new(fs));
+        assert_eq!(
+            TimerType::Increasing,
+            timer_func(attester.clone()).timer_type()
         );
 
-        with_featureset(features_config(vec![Feature::Linear], vec![]), || {
-            let timer_func = get_round_timer_func();
-            assert_eq!(
-                TimerType::EagerDoubleLinear,
-                timer_func(attester).timer_type()
-            );
-            assert_eq!(TimerType::Linear, timer_func(proposer).timer_type());
-        });
+        let fs = featureset(vec![Feature::Linear], vec![Feature::EagerDoubleLinear]);
+        let timer_func = get_round_timer_func(Arc::new(fs));
+        assert_eq!(
+            TimerType::Increasing,
+            timer_func(attester.clone()).timer_type()
+        );
+
+        let fs = featureset(vec![Feature::Linear], vec![]);
+        let timer_func = get_round_timer_func(Arc::new(fs));
+        assert_eq!(
+            TimerType::EagerDoubleLinear,
+            timer_func(attester).timer_type()
+        );
+        assert_eq!(TimerType::Linear, timer_func(proposer).timer_type());
     }
 
     #[tokio::test(start_paused = true)]
     async fn proposal_timeout_optimization_increasing_round_timer() {
         let duty = Duty::new_proposer_duty(SlotNumber::from(0));
-        let timer = IncreasingRoundTimer::with_duty(duty);
+        let timer = IncreasingRoundTimer::with_duty(duty, proposal_timeout_fs());
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || must_timer(timer.timer(1)),
-        );
+        let timeout = must_timer(timer.timer(1));
         assert_fires_after(
             timeout,
             Duration::from_millis(1_500),
@@ -555,10 +564,7 @@ mod tests {
         )
         .await;
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || must_timer(timer.timer(2)),
-        );
+        let timeout = must_timer(timer.timer(2));
         assert_fires_after(
             timeout,
             Duration::from_millis(1_250),
@@ -570,12 +576,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn proposal_timeout_optimization_double_eager_linear_round_timer() {
         let duty = Duty::new_proposer_duty(SlotNumber::from(0));
-        let timer = EagerDoubleLinearRoundTimer::with_duty(duty);
+        let timer = EagerDoubleLinearRoundTimer::with_duty(duty, proposal_timeout_fs());
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || must_timer(timer.timer(1)),
-        );
+        let timeout = must_timer(timer.timer(1));
         assert_fires_after(
             timeout,
             Duration::from_millis(1_500),
@@ -583,10 +586,7 @@ mod tests {
         )
         .await;
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || must_timer(timer.timer(2)),
-        );
+        let timeout = must_timer(timer.timer(2));
         assert_fires_after(
             timeout,
             Duration::from_millis(2_000),
@@ -598,15 +598,12 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn proposal_timeout_optimization_double_eager_linear_round_one_doubles() {
         let duty = Duty::new_proposer_duty(SlotNumber::from(0));
-        let timer = EagerDoubleLinearRoundTimer::with_duty(duty);
+        let timer = EagerDoubleLinearRoundTimer::with_duty(duty, proposal_timeout_fs());
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || {
-                drop(must_timer(timer.timer(1)));
-                must_timer(timer.timer(1))
-            },
-        );
+        let timeout = {
+            drop(must_timer(timer.timer(1)));
+            must_timer(timer.timer(1))
+        };
         let timeout = spawn_timeout(timeout);
         advance(Duration::from_millis(2_500)).await;
         tokio::task::yield_now().await;
@@ -625,12 +622,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn proposal_timeout_optimization_linear_round_timer() {
         let duty = Duty::new_proposer_duty(SlotNumber::from(0));
-        let timer = LinearRoundTimer::with_duty(duty);
+        let timer = LinearRoundTimer::with_duty(duty, proposal_timeout_fs());
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || must_timer(timer.timer(1)),
-        );
+        let timeout = must_timer(timer.timer(1));
         assert_fires_after(
             timeout,
             Duration::from_millis(1_500),
@@ -638,10 +632,7 @@ mod tests {
         )
         .await;
 
-        let timeout = with_featureset(
-            features_config(vec![Feature::ProposalTimeout], vec![]),
-            || must_timer(timer.timer(3)),
-        );
+        let timeout = must_timer(timer.timer(3));
         let want = Duration::from_millis(600);
         assert_eq!(want, must_duration(linear_subsequent_round_timeout(3)));
         assert_fires_after(timeout, want, "round 3 proposer timer did not fire").await;
@@ -779,42 +770,12 @@ mod tests {
         }
     }
 
-    fn with_featureset<T>(config: Config, test: impl FnOnce() -> T) -> T {
-        let _guard = FeatureSetGuard::new(config);
-        test()
+    fn featureset(enabled: Vec<Feature>, disabled: Vec<Feature>) -> FeatureSet {
+        FeatureSet::from_config(features_config(enabled, disabled))
+            .expect("test featureset is valid")
     }
 
-    struct FeatureSetGuard {
-        previous: Option<FeatureSet>,
-        _lock: MutexGuard<'static, ()>,
-    }
-
-    impl FeatureSetGuard {
-        fn new(config: Config) -> Self {
-            let lock = FEATURESET_TEST_LOCK
-                .lock()
-                .expect("featureset test lock poisoned");
-            let replacement = FeatureSet::from_config(config).expect("test featureset is valid");
-            let mut global = GLOBAL_STATE
-                .write()
-                .expect("global feature set lock poisoned");
-            let previous = mem::replace(&mut *global, replacement);
-            drop(global);
-
-            Self {
-                previous: Some(previous),
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for FeatureSetGuard {
-        fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
-                *GLOBAL_STATE
-                    .write()
-                    .expect("global feature set lock poisoned") = previous;
-            }
-        }
+    fn proposal_timeout_fs() -> Arc<FeatureSet> {
+        Arc::new(featureset(vec![Feature::ProposalTimeout], vec![]))
     }
 }

--- a/crates/core/src/tracker/analysis.rs
+++ b/crates/core/src/tracker/analysis.rs
@@ -1,13 +1,10 @@
 //! Pure analysis functions for tracker duty failure detection and peer
 //! participation accounting.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::OnceLock,
-};
+use std::collections::{HashMap, HashSet};
 
 use pluto_eth2api::EthBeaconNodeApiClientError;
-use pluto_featureset::{Feature, GLOBAL_STATE};
+use pluto_featureset::{Feature, FeatureSet};
 use pluto_ssz::HashRoot;
 
 use crate::{
@@ -42,30 +39,22 @@ pub(crate) fn msg_roots_consistent(parsigs: &ParSigsByMsg) -> bool {
     parsigs.values().all(|roots| roots.len() <= 1)
 }
 
-/// Set of duty types for which chain inclusion is supported.
-///
-/// The result is cached for the lifetime of the process. This assumes
-/// `GLOBAL_STATE` (and therefore `Feature::AttestationInclusion`) is
-/// configured once at startup and never mutated afterward — matching Go,
-/// which reads the flag on every call but relies on the same invariant.
-pub(crate) fn incl_supported() -> &'static HashSet<DutyType> {
-    static CACHE: OnceLock<HashSet<DutyType>> = OnceLock::new();
-    CACHE.get_or_init(|| {
-        let mut set = HashSet::new();
-        set.insert(DutyType::Proposer);
-        let state = GLOBAL_STATE.read().expect("featureset poisoned");
-        if state.enabled(Feature::AttestationInclusion) {
-            set.insert(DutyType::Attester);
-            set.insert(DutyType::Aggregator);
-        }
-        set
-    })
+/// Duty types for which on-chain inclusion is tracked: always proposers, plus
+/// attesters and aggregators when `AttestationInclusion` is enabled.
+pub(crate) fn incl_supported(fs: &FeatureSet) -> HashSet<DutyType> {
+    let mut set = HashSet::new();
+    set.insert(DutyType::Proposer);
+    if fs.enabled(Feature::AttestationInclusion) {
+        set.insert(DutyType::Attester);
+        set.insert(DutyType::Aggregator);
+    }
+    set
 }
 
 /// Returns the terminal step for a duty type — either `Bcast` or
 /// `ChainInclusion` depending on whether inclusion checks are supported.
-pub(crate) fn last_step(duty_type: &DutyType) -> Step {
-    if incl_supported().contains(duty_type) {
+pub(crate) fn last_step(duty_type: &DutyType, feature_set: &FeatureSet) -> Step {
+    if incl_supported(feature_set).contains(duty_type) {
         Step::ChainInclusion
     } else {
         Step::Bcast
@@ -108,7 +97,7 @@ pub(crate) struct DutyFailedStep {
 ///
 /// An empty event slice indicates a duty
 /// that failed before any event was recorded (returns `step = Zero`).
-pub(crate) fn duty_failed_step(events: &[Event]) -> DutyFailedStep {
+pub(crate) fn duty_failed_step(events: &[Event], feature_set: &FeatureSet) -> DutyFailedStep {
     if events.is_empty() {
         return DutyFailedStep {
             failed: true,
@@ -154,7 +143,7 @@ pub(crate) fn duty_failed_step(events: &[Event]) -> DutyFailedStep {
 
     // Determine if the final step was successful. Use the duty type from the
     // first event (all events in the slice share the same duty).
-    let last_for_duty = last_step(&events[0].duty.duty_type);
+    let last_for_duty = last_step(&events[0].duty.duty_type, feature_set);
     if last.step == last_for_duty && last.step_err.is_none() {
         return DutyFailedStep {
             failed: false,
@@ -176,6 +165,7 @@ pub(crate) fn analyse_duty_failed(
     all_events: &HashMap<Duty, Vec<Event>>,
     failed_step: &DutyFailedStep,
     msg_root_consistent: bool,
+    feature_set: &FeatureSet,
 ) -> Option<DutyFailure> {
     if !failed_step.failed {
         return None;
@@ -186,7 +176,7 @@ pub(crate) fn analyse_duty_failed(
     let mut err = failed_step.err.clone();
 
     match failed_step.step {
-        Step::Fetcher => return analyse_fetcher_failed(duty, all_events, err),
+        Step::Fetcher => return analyse_fetcher_failed(duty, all_events, err, feature_set),
         Step::Consensus => {
             if err.is_some() {
                 reason = REASON_NO_CONSENSUS;
@@ -266,12 +256,20 @@ pub(crate) fn analyse_fetcher_failed(
     duty: &Duty,
     all_events: &HashMap<Duty, Vec<Event>>,
     fetch_err: Option<StepError>,
+    feature_set: &FeatureSet,
 ) -> Option<DutyFailure> {
     match &duty.duty_type {
-        DutyType::Proposer => Some(analyse_fetcher_failed_proposer(duty, all_events, fetch_err)),
-        DutyType::Aggregator => analyse_fetcher_failed_aggregator(duty, all_events, fetch_err),
+        DutyType::Proposer => Some(analyse_fetcher_failed_proposer(
+            duty,
+            all_events,
+            fetch_err,
+            feature_set,
+        )),
+        DutyType::Aggregator => {
+            analyse_fetcher_failed_aggregator(duty, all_events, fetch_err, feature_set)
+        }
         DutyType::SyncContribution => {
-            analyse_fetcher_failed_sync_contribution(duty, all_events, fetch_err)
+            analyse_fetcher_failed_sync_contribution(duty, all_events, fetch_err, feature_set)
         }
         _ => {
             // TODO: when the fetcher is ported, add an `is_cancelled_error` check here
@@ -298,13 +296,14 @@ fn analyse_fetcher_failed_proposer(
     duty: &Duty,
     all_events: &HashMap<Duty, Vec<Event>>,
     fetch_err: Option<StepError>,
+    feature_set: &FeatureSet,
 ) -> DutyFailure {
     let randao_duty = Duty::new_randao_duty(duty.slot);
     let randao_events = all_events
         .get(&randao_duty)
         .map(Vec::as_slice)
         .unwrap_or(&[]);
-    let randao = duty_failed_step(randao_events);
+    let randao = duty_failed_step(randao_events, feature_set);
 
     let reason = if randao.failed {
         match randao.step {
@@ -328,6 +327,7 @@ fn analyse_fetcher_failed_aggregator(
     duty: &Duty,
     all_events: &HashMap<Duty, Vec<Event>>,
     fetch_err: Option<StepError>,
+    feature_set: &FeatureSet,
 ) -> Option<DutyFailure> {
     fetch_err.as_ref()?;
 
@@ -336,7 +336,7 @@ fn analyse_fetcher_failed_aggregator(
         .get(&prep_agg_duty)
         .map(Vec::as_slice)
         .unwrap_or(&[]);
-    let prep = duty_failed_step(prep_events);
+    let prep = duty_failed_step(prep_events, feature_set);
 
     if prep.failed {
         let reason = match prep.step {
@@ -357,7 +357,7 @@ fn analyse_fetcher_failed_aggregator(
         .get(&attester_duty)
         .map(Vec::as_slice)
         .unwrap_or(&[]);
-    let att = duty_failed_step(att_events);
+    let att = duty_failed_step(att_events, feature_set);
 
     let reason = if att.failed && att.step <= Step::DutyDB {
         REASON_MISSING_AGGREGATOR_ATTESTATION
@@ -376,12 +376,13 @@ fn analyse_fetcher_failed_sync_contribution(
     duty: &Duty,
     all_events: &HashMap<Duty, Vec<Event>>,
     fetch_err: Option<StepError>,
+    feature_set: &FeatureSet,
 ) -> Option<DutyFailure> {
     fetch_err.as_ref()?;
 
     let prep_duty = Duty::new_prepare_sync_contribution_duty(duty.slot);
     let prep_events = all_events.get(&prep_duty).map(Vec::as_slice).unwrap_or(&[]);
-    let prep = duty_failed_step(prep_events);
+    let prep = duty_failed_step(prep_events, feature_set);
 
     if prep.failed {
         let reason = match prep.step {
@@ -402,7 +403,7 @@ fn analyse_fetcher_failed_sync_contribution(
         .get(&sync_msg_duty)
         .map(Vec::as_slice)
         .unwrap_or(&[]);
-    let sync = duty_failed_step(sync_events);
+    let sync = duty_failed_step(sync_events, feature_set);
 
     let reason = if sync.failed && sync.step <= Step::AggSigDB {
         REASON_SYNC_CONTRIBUTION_NO_SYNC_MSG
@@ -587,6 +588,13 @@ mod tests {
         PubKey::from([byte; 48])
     }
 
+    /// Default feature set for analysis tests, matching the previous global
+    /// default (`AttestationInclusion` disabled ⇒ only proposers track chain
+    /// inclusion).
+    fn fs() -> FeatureSet {
+        FeatureSet::new()
+    }
+
     /// Computes the failed step for `duty` and runs the failure analysis,
     /// mirroring how `TrackerService::analyse` wires the two together.
     fn analyse_failed(
@@ -594,8 +602,9 @@ mod tests {
         events: &HashMap<Duty, Vec<Event>>,
         msg_root_consistent: bool,
     ) -> Option<DutyFailure> {
-        let failed_step = duty_failed_step(events.get(duty).map(Vec::as_slice).unwrap_or(&[]));
-        analyse_duty_failed(duty, events, &failed_step, msg_root_consistent)
+        let fs = fs();
+        let failed_step = duty_failed_step(events.get(duty).map(Vec::as_slice).unwrap_or(&[]), &fs);
+        analyse_duty_failed(duty, events, &failed_step, msg_root_consistent, &fs)
     }
 
     fn evt(duty: Duty, step: Step) -> Event {
@@ -842,7 +851,7 @@ mod tests {
     #[test]
     fn analyse_duty_failed_attester_success() {
         let att = Duty::new_attester_duty(SlotNumber::new(1));
-        assert_eq!(last_step(&att.duty_type), Step::Bcast);
+        assert_eq!(last_step(&att.duty_type, &fs()), Step::Bcast);
 
         // Events for every step up to (but not including) chainInclusion.
         let steps = [
@@ -883,12 +892,12 @@ mod tests {
         ];
         let events: Vec<Event> = steps.iter().map(|s| evt(att.clone(), *s)).collect();
 
-        let r = duty_failed_step(&events);
+        let r = duty_failed_step(&events, &fs());
         assert!(!r.failed);
         assert_eq!(r.step, Step::Zero);
         assert!(r.err.is_none());
 
-        let r = duty_failed_step(&[]);
+        let r = duty_failed_step(&[], &fs());
         assert!(r.failed);
         assert_eq!(r.step, Step::Zero);
         assert!(r.err.is_none());
@@ -918,7 +927,7 @@ mod tests {
             }
         }
 
-        let r = duty_failed_step(&events);
+        let r = duty_failed_step(&events, &fs());
         assert!(r.failed);
         assert_eq!(r.step, Step::Bcast);
         assert!(r.err.is_some());
@@ -928,7 +937,7 @@ mod tests {
         for s in steps {
             events.push(evt(att.clone(), s));
         }
-        let r = duty_failed_step(&events);
+        let r = duty_failed_step(&events, &fs());
         assert!(!r.failed);
         assert_eq!(r.step, Step::Zero);
         assert!(r.err.is_none());
@@ -1239,7 +1248,7 @@ mod tests {
                 // slot) must surface as `Step::Fetcher` so the metrics reporter
                 // skips them rather than counting a success.
                 assert_eq!(
-                    duty_failed_step(&c.events[&c.duty]).step,
+                    duty_failed_step(&c.events[&c.duty], &fs()).step,
                     Step::Fetcher,
                     "{}: expected fetcher no-op step",
                     c.name

--- a/crates/core/src/tracker/analysis.rs
+++ b/crates/core/src/tracker/analysis.rs
@@ -588,13 +588,6 @@ mod tests {
         PubKey::from([byte; 48])
     }
 
-    /// Default feature set for analysis tests, matching the previous global
-    /// default (`AttestationInclusion` disabled ⇒ only proposers track chain
-    /// inclusion).
-    fn fs() -> FeatureSet {
-        FeatureSet::new()
-    }
-
     /// Computes the failed step for `duty` and runs the failure analysis,
     /// mirroring how `TrackerService::analyse` wires the two together.
     fn analyse_failed(
@@ -602,7 +595,7 @@ mod tests {
         events: &HashMap<Duty, Vec<Event>>,
         msg_root_consistent: bool,
     ) -> Option<DutyFailure> {
-        let fs = fs();
+        let fs = FeatureSet::new();
         let failed_step = duty_failed_step(events.get(duty).map(Vec::as_slice).unwrap_or(&[]), &fs);
         analyse_duty_failed(duty, events, &failed_step, msg_root_consistent, &fs)
     }
@@ -851,7 +844,7 @@ mod tests {
     #[test]
     fn analyse_duty_failed_attester_success() {
         let att = Duty::new_attester_duty(SlotNumber::new(1));
-        assert_eq!(last_step(&att.duty_type, &fs()), Step::Bcast);
+        assert_eq!(last_step(&att.duty_type, &FeatureSet::new()), Step::Bcast);
 
         // Events for every step up to (but not including) chainInclusion.
         let steps = [
@@ -892,12 +885,12 @@ mod tests {
         ];
         let events: Vec<Event> = steps.iter().map(|s| evt(att.clone(), *s)).collect();
 
-        let r = duty_failed_step(&events, &fs());
+        let r = duty_failed_step(&events, &FeatureSet::new());
         assert!(!r.failed);
         assert_eq!(r.step, Step::Zero);
         assert!(r.err.is_none());
 
-        let r = duty_failed_step(&[], &fs());
+        let r = duty_failed_step(&[], &FeatureSet::new());
         assert!(r.failed);
         assert_eq!(r.step, Step::Zero);
         assert!(r.err.is_none());
@@ -927,7 +920,7 @@ mod tests {
             }
         }
 
-        let r = duty_failed_step(&events, &fs());
+        let r = duty_failed_step(&events, &FeatureSet::new());
         assert!(r.failed);
         assert_eq!(r.step, Step::Bcast);
         assert!(r.err.is_some());
@@ -937,7 +930,7 @@ mod tests {
         for s in steps {
             events.push(evt(att.clone(), s));
         }
-        let r = duty_failed_step(&events, &fs());
+        let r = duty_failed_step(&events, &FeatureSet::new());
         assert!(!r.failed);
         assert_eq!(r.step, Step::Zero);
         assert!(r.err.is_none());
@@ -1248,7 +1241,7 @@ mod tests {
                 // slot) must surface as `Step::Fetcher` so the metrics reporter
                 // skips them rather than counting a success.
                 assert_eq!(
-                    duty_failed_step(&c.events[&c.duty], &fs()).step,
+                    duty_failed_step(&c.events[&c.duty], &FeatureSet::new()).step,
                     Step::Fetcher,
                     "{}: expected fetcher no-op step",
                     c.name

--- a/crates/core/src/tracker/inclusion.rs
+++ b/crates/core/src/tracker/inclusion.rs
@@ -607,19 +607,19 @@ mod tests {
     /// Shared recorder of duties passed to a callback.
     type Rec = Arc<Mutex<Vec<Duty>>>;
 
-    /// Feature set with `AttestationInclusion` toggled, so the real
-    /// `submitted()` gate accepts attester/aggregator duties in tests.
-    fn featureset(attestation_inclusion: bool) -> FeatureSet {
+    fn featureset(attestation_inclusion: bool) -> Arc<FeatureSet> {
         let enabled = if attestation_inclusion {
             vec![Feature::AttestationInclusion]
         } else {
             vec![]
         };
-        FeatureSet::from_config(Config {
-            enabled,
-            ..Config::default()
-        })
-        .expect("test featureset is valid")
+        Arc::new(
+            FeatureSet::from_config(Config {
+                enabled,
+                ..Config::default()
+            })
+            .expect("test featureset is valid"),
+        )
     }
 
     fn pubkey() -> PubKey {
@@ -705,7 +705,7 @@ mod tests {
             Box::new(move |sub: &Submission, _b: &Block| {
                 inc.lock().unwrap().push(sub.duty.clone())
             }),
-            Arc::new(featureset(true)),
+            featureset(true),
         );
 
         let att1 = Attestation::new(phase0_attestation(1));
@@ -777,7 +777,7 @@ mod tests {
                 Box::new(|_d: &Duty, _pk, _err| {}),
                 Box::new(move |sub: &Submission| mis.lock().unwrap().push(sub.duty.clone())),
                 Box::new(|_s: &Submission, _b: &Block| {}),
-                Arc::new(featureset(false)),
+                featureset(false),
             );
 
             // The duty slot is independent of the proposal's internal slot;
@@ -813,7 +813,7 @@ mod tests {
             Box::new(move |_d: &Duty, _pk, err: Option<StepError>| res.lock().unwrap().push(err)),
             Box::new(move |sub: &Submission| mis.lock().unwrap().push(sub.duty.clone())),
             Box::new(|_s: &Submission, _b: &Block| {}),
-            Arc::new(featureset(false)),
+            featureset(false),
         );
 
         core.submitted(

--- a/crates/core/src/tracker/inclusion.rs
+++ b/crates/core/src/tracker/inclusion.rs
@@ -18,6 +18,7 @@
 use std::{any::Any, collections::HashMap, sync::Arc, time::Duration};
 
 use pluto_eth2api::versioned;
+use pluto_featureset::FeatureSet;
 use pluto_ssz::{BitList, HashRoot};
 use tree_hash::TreeHash;
 
@@ -153,16 +154,18 @@ pub struct InclusionCore {
     tracker_incl_fn: TrackerInclFn,
     missed_fn: MissedFn,
     att_included_fn: AttIncludedFn,
+    feature_set: Arc<FeatureSet>,
 }
 
 impl InclusionCore {
     /// Creates a core with the production reporters ([`report_missed`] and
     /// [`report_att_inclusion`]) and the given tracker callback.
-    pub fn new(tracker_incl_fn: TrackerInclFn) -> Self {
+    pub fn new(tracker_incl_fn: TrackerInclFn, feature_set: Arc<FeatureSet>) -> Self {
         Self::with_handlers(
             tracker_incl_fn,
             Box::new(report_missed),
             Box::new(report_att_inclusion),
+            feature_set,
         )
     }
 
@@ -171,6 +174,7 @@ impl InclusionCore {
         tracker_incl_fn: TrackerInclFn,
         missed_fn: MissedFn,
         att_included_fn: AttIncludedFn,
+        feature_set: Arc<FeatureSet>,
     ) -> Self {
         Self {
             submissions: HashMap::new(),
@@ -178,6 +182,7 @@ impl InclusionCore {
             tracker_incl_fn,
             missed_fn,
             att_included_fn,
+            feature_set,
         }
     }
 
@@ -192,7 +197,7 @@ impl InclusionCore {
         data: Box<dyn SignedData>,
         delay: Duration,
     ) -> Result<(), InclusionError> {
-        if !incl_supported().contains(&duty.duty_type) {
+        if !incl_supported(&self.feature_set).contains(&duty.duty_type) {
             return Ok(());
         }
 
@@ -566,23 +571,6 @@ fn report_att_inclusion(sub: &Submission, block: &Block) {
     TRACKER_METRICS.inclusion_delay.set(inclusion_delay_f64);
 }
 
-#[cfg(test)]
-impl InclusionCore {
-    /// Inserts a submission directly, bypassing [`InclusionCore::submitted`]'s
-    /// `incl_supported` feature gate. Used by tests that exercise the inclusion
-    /// checks for attester/aggregator duties without toggling the (cached,
-    /// process-global) `AttestationInclusion` feature.
-    fn insert_submission(&mut self, sub: Submission) {
-        self.submissions.insert(
-            SubKey {
-                duty: sub.duty.clone(),
-                pubkey: sub.pubkey,
-            },
-            sub,
-        );
-    }
-}
-
 /// Logs that a proposer's block was included on-chain.
 fn log_block_included(sub: &Submission, block_slot: u64, blinded: bool) {
     let msg = if blinded {
@@ -611,11 +599,28 @@ mod tests {
     use pluto_testutil::random::random_deneb_versioned_attestation;
     use tree_hash::TreeHash;
 
+    use pluto_featureset::{Config, Feature};
+
     use super::*;
     use crate::types::SlotNumber;
 
     /// Shared recorder of duties passed to a callback.
     type Rec = Arc<Mutex<Vec<Duty>>>;
+
+    /// Feature set with `AttestationInclusion` toggled, so the real
+    /// `submitted()` gate accepts attester/aggregator duties in tests.
+    fn featureset(attestation_inclusion: bool) -> FeatureSet {
+        let enabled = if attestation_inclusion {
+            vec![Feature::AttestationInclusion]
+        } else {
+            vec![]
+        };
+        FeatureSet::from_config(Config {
+            enabled,
+            ..Config::default()
+        })
+        .expect("test featureset is valid")
+    }
 
     fn pubkey() -> PubKey {
         PubKey::from([0u8; 48])
@@ -700,6 +705,7 @@ mod tests {
             Box::new(move |sub: &Submission, _b: &Block| {
                 inc.lock().unwrap().push(sub.duty.clone())
             }),
+            Arc::new(featureset(true)),
         );
 
         let att1 = Attestation::new(phase0_attestation(1));
@@ -707,30 +713,37 @@ mod tests {
         let att3 = Attestation::new(phase0_attestation(3));
         let block4 = proposal();
 
-        let att1_root = att1.0.data.tree_hash_root().0;
+        // Seeded into the block below; the rest are recomputed inside `submitted`.
         let agg2_root = agg2.0.message.aggregate.data.tree_hash_root().0;
-        let att3_root = att3.0.data.tree_hash_root().0;
 
-        core.insert_submission(submission(
+        core.submitted(
             Duty::new_attester_duty(SlotNumber::new(1)),
+            pubkey(),
             Box::new(att1),
-            att1_root,
-        ));
-        core.insert_submission(submission(
+            Duration::ZERO,
+        )
+        .expect("submit attester 1");
+        core.submitted(
             Duty::new_aggregator_duty(SlotNumber::new(2)),
+            pubkey(),
             Box::new(agg2),
-            agg2_root,
-        ));
-        core.insert_submission(submission(
+            Duration::ZERO,
+        )
+        .expect("submit aggregator 2");
+        core.submitted(
             Duty::new_attester_duty(SlotNumber::new(3)),
+            pubkey(),
             Box::new(att3),
-            att3_root,
-        ));
-        core.insert_submission(submission(
+            Duration::ZERO,
+        )
+        .expect("submit attester 3");
+        core.submitted(
             Duty::new_proposer_duty(SlotNumber::new(100)),
+            pubkey(),
             Box::new(block4),
-            [0u8; 32],
-        ));
+            Duration::ZERO,
+        )
+        .expect("submit proposer 100");
 
         // The aggregator lookup must find a block attestation at its data root
         // before failing the versioned downcast, so seed one.
@@ -764,6 +777,7 @@ mod tests {
                 Box::new(|_d: &Duty, _pk, _err| {}),
                 Box::new(move |sub: &Submission| mis.lock().unwrap().push(sub.duty.clone())),
                 Box::new(|_s: &Submission, _b: &Block| {}),
+                Arc::new(featureset(false)),
             );
 
             // The duty slot is independent of the proposal's internal slot;
@@ -799,6 +813,7 @@ mod tests {
             Box::new(move |_d: &Duty, _pk, err: Option<StepError>| res.lock().unwrap().push(err)),
             Box::new(move |sub: &Submission| mis.lock().unwrap().push(sub.duty.clone())),
             Box::new(|_s: &Submission, _b: &Block| {}),
+            Arc::new(featureset(false)),
         );
 
         core.submitted(

--- a/crates/core/src/tracker/mod.rs
+++ b/crates/core/src/tracker/mod.rs
@@ -32,6 +32,7 @@ pub mod inclusion;
 
 use std::{collections::HashMap, future::Future, sync::Arc};
 
+use pluto_featureset::FeatureSet;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -341,6 +342,7 @@ pub struct TrackerService {
     failed_duty_reporter: Box<dyn DutyResultReporter>,
     participation_reporter: Box<dyn ParticipationReporter>,
     unsupported_ignorer: UnsupportedIgnorer,
+    feature_set: Arc<FeatureSet>,
 }
 
 impl TrackerService {
@@ -354,6 +356,7 @@ impl TrackerService {
     /// Both `analyser` and `deleter` must have been started with the same
     /// `cancel` token as passed here, so that all three components shut down
     /// together.
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         cancel: CancellationToken,
         analyser: DeadlinerHandle,
@@ -362,6 +365,7 @@ impl TrackerService {
         deleter_rx: DeleterRx,
         peers: Vec<PeerInfo>,
         from_slot: u64,
+        feature_set: Arc<FeatureSet>,
     ) -> Arc<TrackerHandle> {
         Self::start_with_buffer_and_sinks(
             cancel,
@@ -373,6 +377,7 @@ impl TrackerService {
             EVENT_BUFFER,
             Box::new(MetricsDutyReporter::new()),
             Box::new(MetricsParticipationReporter::new(peers)),
+            feature_set,
         )
     }
 
@@ -387,6 +392,7 @@ impl TrackerService {
         buffer: usize,
         failed_duty_reporter: Box<dyn DutyResultReporter>,
         participation_reporter: Box<dyn ParticipationReporter>,
+        feature_set: Arc<FeatureSet>,
     ) -> Arc<TrackerHandle> {
         let (input_tx, input_rx) = mpsc::channel(buffer);
 
@@ -401,6 +407,7 @@ impl TrackerService {
             failed_duty_reporter,
             participation_reporter,
             unsupported_ignorer: UnsupportedIgnorer::new(),
+            feature_set,
         };
 
         let task = tokio::spawn(task.run());
@@ -413,9 +420,14 @@ impl TrackerService {
         let parsigs = extract_par_sigs(duty_events);
         report_par_sigs(duty, &parsigs);
 
-        let failed_step = duty_failed_step(duty_events);
-        let outcome =
-            analyse_duty_failed(duty, events, &failed_step, msg_roots_consistent(&parsigs));
+        let failed_step = duty_failed_step(duty_events, &self.feature_set);
+        let outcome = analyse_duty_failed(
+            duty,
+            events,
+            &failed_step,
+            msg_roots_consistent(&parsigs),
+            &self.feature_set,
+        );
 
         if self.unsupported_ignorer.check(duty, outcome.as_ref()) {
             return;
@@ -632,6 +644,7 @@ mod tests {
             EVENT_BUFFER,
             failure_sink,
             participation_sink,
+            Arc::new(pluto_featureset::FeatureSet::new()),
         );
 
         (handle, analyser_tx, deleter_tx)
@@ -712,6 +725,7 @@ mod tests {
             DeleterRx(deleter_rx),
             vec![],
             from_slot,
+            Arc::new(pluto_featureset::FeatureSet::new()),
         )
     }
 
@@ -799,6 +813,7 @@ mod tests {
             DeleterRx(deleter_rx),
             vec![],
             0,
+            Arc::new(pluto_featureset::FeatureSet::new()),
         );
 
         let duty = attester(1);

--- a/crates/featureset/src/lib.rs
+++ b/crates/featureset/src/lib.rs
@@ -1,15 +1,28 @@
 //! # Featureset
 //!
-//! Defines a set of global features and their rollout status.
+//! Defines the set of features and their rollout status. Features are enabled
+//! or disabled via [`Config`], and [`Config::min_status`] gates which are on by
+//! default.
 //!
-//! Features can be enabled or disabled via configuration, and the minimum
-//! status determines which features are enabled by default.
+//! ## Usage: inject, don't globalize
+//!
+//! There is intentionally **no global feature state** (no `GLOBAL_STATE`).
+//! Build one [`FeatureSet`] during application wiring and **inject it as
+//! `Arc<FeatureSet>`** into every component that reads a feature (consensus,
+//! round timers, tracker, …); each reads it via [`FeatureSet::enabled`].
+//!
+//! Resolve it once at startup:
+//! 1. `FeatureSet::from_config(cfg)`.
+//! 2. For gnosis/chiado, `enable_gnosis_block_hotfix_if_not_disabled(&cfg)`
+//!    (needs `&mut`) — apply this *before* wrapping in `Arc`.
+//! 3. `Arc::new(fs)`, then share read-only.
+//!
+//! Feature state is configured once at startup and never mutated afterward. The
+//! immutable `Arc<FeatureSet>` encodes that invariant at the type level: no
+//! lock on the (hot) read path, and tests construct their own set instead of
+//! mutating shared state.
 
-use std::{
-    collections::HashMap,
-    fmt,
-    sync::{LazyLock, RwLock},
-};
+use std::{collections::HashMap, fmt};
 
 use thiserror::Error;
 
@@ -159,7 +172,8 @@ pub enum FeaturesetError {
 
 type Result<T> = std::result::Result<T, FeaturesetError>;
 
-/// Global state for feature statuses.
+/// Resolved feature statuses for a node, injected where features are read.
+#[derive(Debug, Clone)]
 pub struct FeatureSet {
     /// Defines the current rollout status of each feature.
     pub state: HashMap<Feature, Status>,
@@ -263,10 +277,6 @@ impl FeatureSet {
         custom_enabled_features
     }
 }
-
-/// Global feature set state.
-pub static GLOBAL_STATE: LazyLock<RwLock<FeatureSet>> =
-    LazyLock::new(|| RwLock::new(FeatureSet::new()));
 
 /// Config configures the feature set package.
 #[derive(Debug, Clone)]

--- a/crates/infosync/src/lib.rs
+++ b/crates/infosync/src/lib.rs
@@ -16,7 +16,7 @@ use pluto_core::{
     types::{Duty, ProposalType, SlotNumber},
     version::SemVer,
 };
-use pluto_featureset::Feature;
+use pluto_featureset::{Feature, FeatureSet};
 use pluto_priority::{Component as Prioritiser, TopicProposal, TopicResult};
 use tokio_util::sync::CancellationToken;
 
@@ -169,10 +169,11 @@ impl Component {
         versions: Vec<SemVer>,
         protocols: Vec<String>,
         proposals: Vec<ProposalType>,
+        feature_set: &FeatureSet,
     ) -> Self {
         let store = Arc::new(ResultStore::new(augment_protocols(
             protocols,
-            mock_alpha_enabled(),
+            feature_set.enabled(Feature::MockAlpha),
         )));
 
         let cb_store = Arc::clone(&store);
@@ -271,14 +272,6 @@ fn augment_protocols(mut protocols: Vec<String>, mock_alpha: bool) -> Vec<String
     }
 
     protocols
-}
-
-/// Returns whether the `MockAlpha` feature is globally enabled.
-fn mock_alpha_enabled() -> bool {
-    pluto_featureset::GLOBAL_STATE
-        .read()
-        .expect("global feature set lock poisoned")
-        .enabled(Feature::MockAlpha)
 }
 
 #[cfg(test)]

--- a/crates/infosync/tests/infosync_integration.rs
+++ b/crates/infosync/tests/infosync_integration.rs
@@ -27,6 +27,7 @@ use pluto_core::{
     types::{Duty, DutyType, ProposalType, SlotNumber},
     version::SUPPORTED,
 };
+use pluto_featureset::FeatureSet;
 use pluto_infosync::Component as InfoSync;
 use pluto_p2p::{p2p_context::P2PContext, peer::peer_id_from_key, utils::keypair_from_secret_key};
 use pluto_priority::{
@@ -166,7 +167,13 @@ fn build_host(
     let prio = Arc::new(prio);
 
     // infosync subscribes to the prioritiser inside `new`.
-    let infosync = Arc::new(InfoSync::new(prio.clone(), versions, protocols, proposals));
+    let infosync = Arc::new(InfoSync::new(
+        prio.clone(),
+        versions,
+        protocols,
+        proposals,
+        &FeatureSet::new(),
+    ));
 
     // Capture subscriber registered after infosync's (fan-out runs in
     // registration order, so a capture message implies infosync is updated).


### PR DESCRIPTION
  Feature state was a process-global `RwLock` (a port of charon's mutex-guarded global), which forced every feature-gated test to serialize on a lock with save/restore guards. This replaces it with an  injected `Arc<FeatureSet>` resolved once at startup. Charon never mutates the state at runtime (only `Init` + the gnosis hotfix during startup), so an immutable `Arc` is behaviorally equivalent and keeps  the read path lock-free.

  **Changes**
  - `featureset`: removed `GLOBAL_STATE`; `FeatureSet` now derives `Debug + Clone`.
  - `consensus`: `Consensus` and the round timers hold `Arc<FeatureSet>` (ConsensusParticipate, ProposalTimeout, Linear/EagerDoubleLinear).
  - `core` tracker: `TrackerService` and `InclusionCore` hold it; `incl_supported` is now a plain function (dropped the `OnceLock` cache).
  - `infosync`: `Component::new` takes `&FeatureSet`.

  Deleted all the test serialization scaffolding (`FEATURESET_TEST_LOCK`, `FeatureSetGuard`, `with_featureset`, `OnceLock`, `insert_submission`) — feature-gated tests now build their own set and run in parallel.