### PR TITLE
fix(cluster): fix charon parity in legacy lock hashing and deserialization

### DIFF
--- a/crates/cluster/src/definition.rs
+++ b/crates/cluster/src/definition.rs
@@ -272,6 +272,10 @@ pub enum DefinitionError {
     #[error("Invalid compounding: the version does not support compounding")]
     InvalidCompounding,
 
+    /// Non-zero operator nonce (v1.0/v1.1 operators must have a zero nonce)
+    #[error("non-zero operator nonce not supported")]
+    NonZeroOperatorNonce,
+
     /// Peer not found
     #[error("Peer not in definition: {peer_id}")]
     PeerNotFound {
@@ -923,6 +927,12 @@ impl TryFrom<DefinitionV1x0or1> for Definition {
         let validator_addresses =
             repeat_v_addresses(validator_addresses, definition.num_validators);
 
+        let operators = definition
+            .operators
+            .into_iter()
+            .map(Operator::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
         Ok(Self {
             name: definition.name,
             uuid: definition.uuid,
@@ -932,11 +942,7 @@ impl TryFrom<DefinitionV1x0or1> for Definition {
             threshold: definition.threshold,
             dkg_algorithm: definition.dkg_algorithm,
             fork_version: definition.fork_version,
-            operators: definition
-                .operators
-                .into_iter()
-                .map(Operator::from)
-                .collect(),
+            operators,
             creator: Creator::default(),
             validator_addresses,
             deposit_amounts: Vec::new(),
@@ -1780,6 +1786,23 @@ mod tests {
         let definition = serde_json::from_str::<Definition>(json_str).unwrap();
 
         assert!(definition.verify_hashes().is_ok());
+    }
+
+    #[test]
+    fn v1x0or1_definition_rejects_non_zero_operator_nonce() {
+        for fixture in [
+            include_str!("testdata/cluster_definition_v1_0_0.json"),
+            include_str!("testdata/cluster_definition_v1_1_0.json"),
+        ] {
+            let mut value: serde_json::Value = serde_json::from_str(fixture).unwrap();
+            value["operators"][0]["nonce"] = serde_json::json!(1);
+
+            let err = serde_json::from_value::<Definition>(value).unwrap_err();
+            assert!(
+                err.to_string().contains("NonZeroOperatorNonce"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cluster/src/lock.rs
+++ b/crates/cluster/src/lock.rs
@@ -1029,6 +1029,31 @@ mod tests {
         assert!(lock.verify_hashes().is_ok());
     }
 
+    #[test]
+    fn legacy_lock_hash_uses_distributed_validator_count() {
+        let mut lock =
+            serde_json::from_str::<Lock>(include_str!("testdata/cluster_lock_v1_2_0.json"))
+                .unwrap();
+        assert!(lock.verify_hashes().is_ok());
+        let golden = lock.lock_hash.clone();
+
+        // Append an identical (so `legacy_validator_addresses` still collapses to a
+        // single address, keeping field (0) unchanged) extra address entry, making
+        // validator_addresses.len() != distributed_validators.len().
+        let extra = lock.definition.validator_addresses[0].clone();
+        lock.definition.validator_addresses.push(extra);
+        assert_ne!(
+            lock.definition.validator_addresses.len(),
+            lock.distributed_validators.len()
+        );
+
+        // Field (1) count must still track distributed_validators, so the legacy
+        // lock hash is unchanged. The buggy field (`validator_addresses.len()`)
+        // would diverge from this golden hash.
+        let recomputed = hash_lock(&lock).expect("hash_lock should not error");
+        assert_eq!(recomputed.to_vec(), golden);
+    }
+
     #[tokio::test]
     async fn verify_signatures_v1_0_allows_empty_aggregate() {
         let mut lock =

--- a/crates/cluster/src/lock.rs
+++ b/crates/cluster/src/lock.rs
@@ -212,10 +212,28 @@ impl<'de> Deserialize<'de> for Lock {
         match version {
             V1_0 | V1_1 => {
                 let lock: LockV1x0or1 = serde_json::from_value(value).map_err(Error::custom)?;
+                if lock
+                    .distributed_validators
+                    .iter()
+                    .any(|v| !v.fee_recipient_address.is_empty())
+                {
+                    return Err(Error::custom(
+                        "distributed validator fee recipient not supported anymore",
+                    ));
+                }
                 Ok(lock.into())
             }
             V1_2 | V1_3 | V1_4 | V1_5 => {
                 let lock: LockV1x2to5 = serde_json::from_value(value).map_err(Error::custom)?;
+                if lock
+                    .distributed_validators
+                    .iter()
+                    .any(|v| !v.fee_recipient_address.is_empty())
+                {
+                    return Err(Error::custom(
+                        "distributed validator fee recipient not supported anymore",
+                    ));
+                }
                 Ok(lock.into())
             }
             V1_6 => {
@@ -1052,6 +1070,25 @@ mod tests {
         // would diverge from this golden hash.
         let recomputed = hash_lock(&lock).expect("hash_lock should not error");
         assert_eq!(recomputed.to_vec(), golden);
+    }
+
+    #[test]
+    fn legacy_lock_rejects_distributed_validator_fee_recipient() {
+        for fixture in [
+            include_str!("testdata/cluster_lock_v1_0_0.json"),
+            include_str!("testdata/cluster_lock_v1_2_0.json"),
+        ] {
+            let mut value: serde_json::Value = serde_json::from_str(fixture).unwrap();
+            value["distributed_validators"][0]["fee_recipient_address"] =
+                serde_json::json!("0x1111111111111111111111111111111111111111");
+
+            let err = serde_json::from_value::<Lock>(value).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("distributed validator fee recipient not supported anymore"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/cluster/src/operator.rs
+++ b/crates/cluster/src/operator.rs
@@ -1,4 +1,4 @@
-use crate::version::ZERO_NONCE;
+use crate::{definition::DefinitionError, version::ZERO_NONCE};
 use pluto_ssz::serde_utils::HexBytes;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -58,14 +58,20 @@ pub struct OperatorV1X2OrLater {
     enr_signature: Vec<u8>,
 }
 
-impl From<OperatorV1X1> for Operator {
-    fn from(operator: OperatorV1X1) -> Self {
-        Self {
+impl TryFrom<OperatorV1X1> for Operator {
+    type Error = DefinitionError;
+
+    fn try_from(operator: OperatorV1X1) -> Result<Self, Self::Error> {
+        if operator.nonce != 0 {
+            return Err(DefinitionError::NonZeroOperatorNonce);
+        }
+
+        Ok(Self {
             address: operator.address,
             enr: operator.enr,
             config_signature: operator.config_signature,
             enr_signature: operator.enr_signature,
-        }
+        })
     }
 }
 

--- a/crates/cluster/src/ssz.rs
+++ b/crates/cluster/src/ssz.rs
@@ -787,7 +787,7 @@ pub(crate) fn hash_lock_legacy<H: HashWalker>(lock: &Lock, hh: &mut H) -> Result
     // Field (1) 'ValidatorAddresses'
     {
         let sub_idx = hh.index();
-        let num = lock.validator_addresses.len();
+        let num = lock.distributed_validators.len();
 
         for validator in &lock.distributed_validators {
             hash_validator_legacy(validator, hh)?;

--- a/crates/cluster/src/ssz.rs
+++ b/crates/cluster/src/ssz.rs
@@ -236,7 +236,12 @@ pub(crate) fn hash_definition_legacy<H: HashWalker>(
     }
 
     // Field (10) 'timestamp' (optional for backwards compatibility)
-    if config_only && !definition.timestamp.is_empty() || definition.version != V1_0 {
+    if config_only {
+        if !definition.timestamp.is_empty() {
+            hh.put_bytes(definition.timestamp.as_bytes())
+                .map_err(SSZError::<H>::HashWalkerError)?;
+        }
+    } else if definition.version != V1_0 {
         hh.put_bytes(definition.timestamp.as_bytes())
             .map_err(SSZError::<H>::HashWalkerError)?;
     }


### PR DESCRIPTION
## Summary
  Charon-parity fixes for the legacy (v1.0–v1.5) cluster lock/definition path (from `shared/audit/cluster.md`).

  ### `fix(cluster): use distributed_validators count for legacy lock hash mixin`
  `hash_lock_legacy` mixed in `validator_addresses.len()` (via `Deref`) instead of `distributed_validators.len()` → divergent legacy `lock_hash` / `CountGreaterThanLimit` when counts differ. Matches
  `ssz.go:714`.

  ### `fix(cluster): reject distributed validator fee recipient in v1.0-v1.5 locks`
  Reject non-empty `distributed_validators[*].fee_recipient_address` on deserialize; pluto silently dropped it. Matches `lock.go:365-369,387-391`.

  ### `fix(cluster): reject non-zero operator nonce in v1.0/v1.1 definitions`
  Reject `operator.nonce != 0` (new `DefinitionError::NonZeroOperatorNonce`); pluto silently dropped it. Matches `operator.go:51`.

  ### `fix(cluster): correct timestamp gating branch in legacy definition hash`
  Fix operator-precedence in the timestamp branch to mirror `ssz.go:146-155`. No behavior change (empty write is a no-op).