### PR TITLE
fix(eth2util): align RLP, Network, ENR & keystore

### DIFF
--- a/crates/cli/src/commands/create_cluster.rs
+++ b/crates/cli/src/commands/create_cluster.rs
@@ -154,15 +154,6 @@ pub struct TestnetConfig {
     pub testnet_name: Option<String>,
 }
 
-impl TestnetConfig {
-    pub fn is_empty(&self) -> bool {
-        self.testnet_name.is_none()
-            && self.fork_version.is_none()
-            && self.chain_id.is_none()
-            && self.genesis_timestamp.is_none()
-    }
-}
-
 /// Arguments for the create cluster command
 #[derive(clap::Args)]
 pub struct CreateClusterArgs {
@@ -1127,10 +1118,11 @@ fn validate_network_config(args: &CreateClusterArgs) -> Result<()> {
         .into());
     }
 
-    // Check if custom testnet configuration is provided.
-    if !args.testnet_config.is_empty() {
+    // Check if a complete custom testnet configuration is provided.
+    let testnet_network: network::Network = args.testnet_config.clone().into();
+    if testnet_network.is_non_zero() {
         // Add testnet config to supported networks.
-        eth2util::network::add_test_network(args.testnet_config.clone().into())?;
+        eth2util::network::add_test_network(testnet_network)?;
 
         return Ok(());
     }

--- a/crates/eth2util/src/enr.rs
+++ b/crates/eth2util/src/enr.rs
@@ -121,10 +121,31 @@ impl EnrEntry {
     fn apply(self, kvs: &mut HashMap<String, Vec<u8>>) {
         let _ = match self {
             Self::Ipv4(ip) => kvs.insert(KEY_IP.to_string(), ip.octets().to_vec()),
-            Self::Tcp(tcp) => kvs.insert(KEY_TCP.to_string(), tcp.to_be_bytes().to_vec()),
-            Self::Udp(udp) => kvs.insert(KEY_UDP.to_string(), udp.to_be_bytes().to_vec()),
+            // Ports are stored as minimal big-endian integers (leading zeros
+            // stripped), so a port < 256 occupies a single byte. This matches
+            // the sequence-number field above and keeps records byte-identical
+            // to peers that encode ports the same way.
+            Self::Tcp(tcp) => kvs.insert(KEY_TCP.to_string(), utils::to_big_endian(tcp.into())),
+            Self::Udp(udp) => kvs.insert(KEY_UDP.to_string(), utils::to_big_endian(udp.into())),
         };
     }
+}
+
+/// Decodes a minimal big-endian port integer into a `u16`.
+///
+/// Ports are stored with leading zeros stripped, so the value may be shorter
+/// than 2 bytes (a port < 256 is 1 byte, and port 0 is empty). The bytes are
+/// left-padded before decoding. Returns `None` if the value is wider than a
+/// `u16`.
+fn port_from_be_bytes(bytes: &[u8]) -> Option<u16> {
+    if bytes.len() > 2 {
+        return None;
+    }
+
+    let mut buf = [0u8; 2];
+    let start = 2usize.saturating_sub(bytes.len());
+    buf[start..].copy_from_slice(bytes);
+    Some(u16::from_be_bytes(buf))
 }
 
 impl Record {
@@ -171,8 +192,7 @@ impl Record {
     /// Returns None if the TCP port is not set.
     pub fn tcp(&self) -> Option<u16> {
         let value = self.kvs.get(KEY_TCP)?;
-        let bytes = value.as_slice().try_into().ok()?;
-        Some(u16::from_be_bytes(bytes))
+        port_from_be_bytes(value)
     }
 
     /// Returns the UDP port of the record.
@@ -180,8 +200,7 @@ impl Record {
     /// Returns None if the UDP port is not set.
     pub fn udp(&self) -> Option<u16> {
         let value = self.kvs.get(KEY_UDP)?;
-        let bytes = value.as_slice().try_into().ok()?;
-        Some(u16::from_be_bytes(bytes))
+        port_from_be_bytes(value)
     }
 }
 
@@ -420,6 +439,35 @@ mod tests {
 
         let udp = r2.udp().expect("UDP port should be set");
         assert_eq!(udp, expect_udp);
+    }
+
+    #[test]
+    fn ports_below_256_are_minimally_encoded_and_roundtrip() {
+        let secret_key: SecretKey<Secp256k1> = generate_insecure_k1_key(0);
+
+        // Ports < 256 have a zero high byte.
+        let r1 = Record::new(&secret_key, vec![EnrEntry::Tcp(80), EnrEntry::Udp(9)])
+            .expect("Failed to create record");
+
+        // Stored minimally (single byte), matching a charon-produced record;
+        // the old `to_be_bytes` encoding would keep a leading `0x00`.
+        assert_eq!(r1.kvs.get(KEY_TCP).unwrap().as_slice(), &[0x50]);
+        assert_eq!(r1.kvs.get(KEY_UDP).unwrap().as_slice(), &[0x09]);
+
+        // Such a record must round-trip through the serialized form rather than
+        // dropping the port (the old fixed 2-byte decode returned `None` here).
+        let r2 = Record::try_from(r1.to_string().as_str()).expect("Failed to parse record");
+        assert_eq!(r2.tcp(), Some(80));
+        assert_eq!(r2.udp(), Some(9));
+    }
+
+    #[test]
+    fn port_from_be_bytes_is_length_tolerant() {
+        assert_eq!(port_from_be_bytes(&[]), Some(0));
+        assert_eq!(port_from_be_bytes(&[0x50]), Some(80));
+        assert_eq!(port_from_be_bytes(&[0x0e, 0x1a]), Some(3610));
+        // Wider than a u16 is rejected rather than silently truncated.
+        assert_eq!(port_from_be_bytes(&[0x01, 0x00, 0x00]), None);
     }
 
     #[test]

--- a/crates/eth2util/src/keystore/keystorev4.rs
+++ b/crates/eth2util/src/keystore/keystorev4.rs
@@ -295,8 +295,8 @@ fn validate_aes_iv(iv: &[u8]) -> Result<()> {
             iv.len()
         )));
     } else if iv.len() != IV_SIZE {
-        eprintln!(
-            "WARN: AES IV length incorrect is {}, should be {IV_SIZE}",
+        tracing::warn!(
+            "AES IV length incorrect is {}, should be {IV_SIZE}",
             iv.len()
         );
     }
@@ -335,9 +335,10 @@ fn validate_parameters(kdf: &Kdf) -> Result<()> {
                 if params.c == 0 {
                     return Err(KeystoreError::InvalidPbkdf2Param);
                 }
-                eprintln!(
-                    "WARN: PBKDF2 parameters are too weak, 'c' is {}, we recommend using {}",
-                    params.c, DEFAULT_PBKDF2_C
+                tracing::warn!(
+                    "PBKDF2 parameters are too weak, 'c' is {}, we recommend using {}",
+                    params.c,
+                    DEFAULT_PBKDF2_C
                 );
             }
 
@@ -386,9 +387,11 @@ fn validate_parameters(kdf: &Kdf) -> Result<()> {
 
             // Minimum Parameters
             if npr < DEFAULT_SCRYPT_NPR {
-                eprintln!(
-                    "WARN: Scrypt parameters are too weak (n: {}, p: {}, r: {}), we recommend (n: {DEFAULT_SCRYPT_N}, p: {DEFAULT_SCRYPT_P}, r: {DEFAULT_SCRYPT_R})",
-                    params.n, params.p, params.r
+                tracing::warn!(
+                    "Scrypt parameters are too weak (n: {}, p: {}, r: {}), we recommend (n: {DEFAULT_SCRYPT_N}, p: {DEFAULT_SCRYPT_P}, r: {DEFAULT_SCRYPT_R})",
+                    params.n,
+                    params.p,
+                    params.r
                 );
             }
 
@@ -411,14 +414,14 @@ fn validate_salt(salt: &[u8]) -> Result<()> {
     if salt.is_empty() {
         return Err(KeystoreError::InvalidSaltLength);
     } else if salt.len() < SALT_SIZE / 2 {
-        eprintln!(
-            "WARN: Salt is too short {}, we recommend {}",
+        tracing::warn!(
+            "Salt is too short {}, we recommend {}",
             salt.len(),
             SALT_SIZE
         );
     } else if salt.len() > SALT_SIZE * 2 {
-        eprintln!(
-            "WARN: Salt is too long {}, we recommend {}",
+        tracing::warn!(
+            "Salt is too long {}, we recommend {}",
             salt.len(),
             SALT_SIZE
         );

--- a/crates/eth2util/src/network.rs
+++ b/crates/eth2util/src/network.rs
@@ -57,10 +57,13 @@ pub struct Network {
 }
 
 impl Network {
-    /// is_non_zero checks if each field in this struct is not equal to its zero
-    /// value.
+    /// is_non_zero checks that the identifying fields of this struct are all
+    /// set to a non-zero value. `capella_hard_fork` is intentionally excluded.
     pub fn is_non_zero(&self) -> bool {
-        self != &Network::default()
+        !self.name.is_empty()
+            && self.chain_id != 0
+            && self.genesis_timestamp != 0
+            && !self.genesis_fork_version_hex.is_empty()
     }
 }
 
@@ -328,6 +331,62 @@ mod tests {
             NetworkError::InvalidName {
                 name: INVALID_NETWORK.to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn is_non_zero_works() {
+        // A fully populated network is non-zero.
+        assert!(MAINNET.is_non_zero());
+
+        // The zero value is not non-zero.
+        assert!(!Network::default().is_non_zero());
+
+        // Every identifying field must be set: dropping any one makes it zero.
+        assert!(
+            !Network {
+                name: "",
+                ..MAINNET
+            }
+            .is_non_zero()
+        );
+        assert!(
+            !Network {
+                chain_id: 0,
+                ..MAINNET
+            }
+            .is_non_zero()
+        );
+        assert!(
+            !Network {
+                genesis_timestamp: 0,
+                ..MAINNET
+            }
+            .is_non_zero()
+        );
+        assert!(
+            !Network {
+                genesis_fork_version_hex: "",
+                ..MAINNET
+            }
+            .is_non_zero()
+        );
+
+        // capella_hard_fork is excluded: it alone does not make a zero value
+        // non-zero, and clearing it on an otherwise populated network is fine.
+        assert!(
+            !Network {
+                capella_hard_fork: "0x03000000",
+                ..Network::default()
+            }
+            .is_non_zero()
+        );
+        assert!(
+            Network {
+                capella_hard_fork: "",
+                ..MAINNET
+            }
+            .is_non_zero()
         );
     }
 

--- a/crates/eth2util/src/rlp.rs
+++ b/crates/eth2util/src/rlp.rs
@@ -146,7 +146,7 @@ fn encode_length(length: usize, offset: u8) -> Vec<u8> {
 /// Decodes a big-endian integer from a byte slice at the given offset and
 /// length.
 fn from_big_endian(bytes: &[u8], offset: usize, length: usize) -> Result<usize> {
-    if offset >= bytes.len() || offset.wrapping_add(length) > bytes.len() {
+    if offset >= bytes.len() || offset.wrapping_add(length) >= bytes.len() {
         return Err(RlpError::InputTooShort);
     }
 
@@ -327,5 +327,17 @@ mod tests {
         // Malformed input: claims to have more data than available
         let result = decode_bytes(&[0x85, 0x01, 0x02]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_big_endian_length_bytes_are_last() {
+        // Long-form prefix (0xb8) whose single length byte is the final byte of
+        // the input, leaving no payload. `from_big_endian` must reject this as
+        // "input too short": a valid long-form encoding always has at least one
+        // payload byte after the length field, so `offset + length` must be
+        // strictly less than the input length. A lax `>` bound would instead
+        // read the length as 0 and return an empty slice rather than erroring.
+        assert!(from_big_endian(&[0xb8, 0x00], 1, 1).is_err());
+        assert!(decode_bytes(&[0xb8, 0x00]).is_err());
     }
 }


### PR DESCRIPTION
  - **fix(eth2util): tighten RLP length bounds check** — `from_big_endian` used `>` where charon uses strict `>=`, so edge-length long-form blobs (e.g. `[0xb8, 0x00]`) decoded to empty instead of being rejected.

  - **fix(cli): gate createcluster testnet config on `Network::is_non_zero`** — `Network::is_non_zero` was `!= default()` (true if *any* field differs); now ANDs the four identifying fields (ignoring  `capella_hard_fork`) like charon's `IsNonZero`. `create_cluster` now gates on it instead of `!TestnetConfig::is_empty()`, so a partial testnet config is rejected like charon. 

  - **fix(eth2util): match charon ENR port encoding + keystore warnings** — encode TCP/UDP ports as minimal big-endian and decode length-tolerantly, so ports < 256 round-trip with charon peers instead of  being dropped / published non-canonically; and route keystore weak-param warnings through `tracing::warn!` instead of `eprintln!`. 