### PR TITLE
fix(logging): redact sensitive credentials from log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5367,6 +5367,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "scrypt",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_with",
@@ -6685,6 +6686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6690,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ scrypt = "0.11.0"
 subtle = "2.6"
 unicode-normalization = "0.1.25"
 zeroize = "1.8.2"
-secrecy = "0.8"
+secrecy = "0.10"
 uuid = { version = "1.19", features = ["serde", "v4"] }
 unsigned-varint = { version = "0.8", features = ["futures"] }
 serde_with = { version = "3.16", features = ["hex", "base64"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ scrypt = "0.11.0"
 subtle = "2.6"
 unicode-normalization = "0.1.25"
 zeroize = "1.8.2"
+secrecy = "0.8"
 uuid = { version = "1.19", features = ["serde", "v4"] }
 unsigned-varint = { version = "0.8", features = ["futures"] }
 serde_with = { version = "3.16", features = ["hex", "base64"] }

--- a/crates/dkg/src/dkg.rs
+++ b/crates/dkg/src/dkg.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ffi::OsStr, num::TryFromIntError, path, time::Duration};
+use std::{collections::HashMap, ffi::OsStr, fmt, num::TryFromIntError, path, time::Duration};
 
 use bon::Builder;
 use futures::StreamExt;
@@ -219,12 +219,21 @@ pub enum DkgError {
 }
 
 /// Keymanager configuration accepted by the entrypoint.
-#[derive(Debug, Clone, Default, Builder)]
+#[derive(Clone, Default, Builder)]
 pub struct KeymanagerConfig {
     /// The keymanager URL.
     pub address: String,
     /// Bearer token used for authentication.
     pub auth_token: String,
+}
+
+impl fmt::Debug for KeymanagerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeymanagerConfig")
+            .field("address", &self.address)
+            .field("auth_token", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Publish configuration accepted by the entrypoint.
@@ -1285,5 +1294,17 @@ mod tests {
             err,
             DkgError::Disk(crate::disk::DiskError::MissingRequiredFiles { .. })
         ));
+    }
+
+    #[test]
+    fn keymanager_config_debug_redacts_auth_token() {
+        let cfg = KeymanagerConfig::builder()
+            .address("https://keymanager.example".to_string())
+            .auth_token("super-secret-token".to_string())
+            .build();
+        let rendered = format!("{cfg:?}");
+        assert!(!rendered.contains("super-secret-token"), "token leaked in Debug: {rendered}");
+        assert!(rendered.contains("<redacted>"), "expected <redacted> marker in Debug: {rendered}");
+        assert!(rendered.contains("https://keymanager.example"), "address should be visible");
     }
 }

--- a/crates/dkg/src/dkg.rs
+++ b/crates/dkg/src/dkg.rs
@@ -1303,8 +1303,17 @@ mod tests {
             .auth_token("super-secret-token".to_string())
             .build();
         let rendered = format!("{cfg:?}");
-        assert!(!rendered.contains("super-secret-token"), "token leaked in Debug: {rendered}");
-        assert!(rendered.contains("<redacted>"), "expected <redacted> marker in Debug: {rendered}");
-        assert!(rendered.contains("https://keymanager.example"), "address should be visible");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "token leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "expected <redacted> marker in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("https://keymanager.example"),
+            "address should be visible"
+        );
     }
 }

--- a/crates/eth2util/Cargo.toml
+++ b/crates/eth2util/Cargo.toml
@@ -21,6 +21,7 @@ pbkdf2.workspace = true
 scrypt.workspace = true
 unicode-normalization.workspace = true
 zeroize.workspace = true
+secrecy.workspace = true
 pluto-k1util.workspace = true
 chrono.workspace = true
 regex.workspace = true

--- a/crates/eth2util/src/keymanager.rs
+++ b/crates/eth2util/src/keymanager.rs
@@ -2,6 +2,7 @@
 //! (https://ethereum.github.io/keymanager-APIs/) functionalities.
 
 use crate::keystore::Keystore;
+use secrecy::{ExposeSecret, Secret};
 use url::Url;
 
 /// Errors that can occur when using the keymanager client.
@@ -63,7 +64,7 @@ pub type Result<T> = std::result::Result<T, KeymanagerError>;
 #[derive(Debug, Clone)]
 pub struct Client {
     base_url: Url,
-    auth_token: String,
+    auth_token: Secret<String>,
     http_client: reqwest::Client,
 }
 
@@ -80,7 +81,7 @@ impl Client {
         };
         Ok(Self {
             base_url: Url::parse(&normalized)?,
-            auth_token: auth_token.as_ref().to_owned(),
+            auth_token: Secret::new(auth_token.as_ref().to_owned()),
             http_client: reqwest::Client::new(),
         })
     }
@@ -143,7 +144,7 @@ impl Client {
             .http_client
             .post(addr)
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", self.auth_token))
+            .header("Authorization", format!("Bearer {}", self.auth_token.expose_secret()))
             .body(req_bytes)
             .timeout(timeout)
             .send()
@@ -337,5 +338,13 @@ mod tests {
     fn parse_url_failures(input: &str) {
         let err = Client::new(input, AUTH_TOKEN).unwrap_err();
         assert!(matches!(err, KeymanagerError::ParseUrl(_)));
+    }
+
+    #[test]
+    fn client_debug_redacts_auth_token() {
+        let client = Client::new("http://localhost:9999", "super-secret-token").unwrap();
+        let rendered = format!("{client:?}");
+        assert!(!rendered.contains("super-secret-token"), "token leaked in Debug: {rendered}");
+        assert!(rendered.contains("REDACTED"), "expected REDACTED marker in Debug: {rendered}");
     }
 }

--- a/crates/eth2util/src/keymanager.rs
+++ b/crates/eth2util/src/keymanager.rs
@@ -2,7 +2,7 @@
 //! (https://ethereum.github.io/keymanager-APIs/) functionalities.
 
 use crate::keystore::Keystore;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use url::Url;
 
 /// Errors that can occur when using the keymanager client.
@@ -64,7 +64,7 @@ pub type Result<T> = std::result::Result<T, KeymanagerError>;
 #[derive(Debug, Clone)]
 pub struct Client {
     base_url: Url,
-    auth_token: Secret<String>,
+    auth_token: SecretString,
     http_client: reqwest::Client,
 }
 
@@ -81,7 +81,7 @@ impl Client {
         };
         Ok(Self {
             base_url: Url::parse(&normalized)?,
-            auth_token: Secret::new(auth_token.as_ref().to_owned()),
+            auth_token: SecretString::from(auth_token.as_ref().to_owned()),
             http_client: reqwest::Client::new(),
         })
     }
@@ -144,7 +144,10 @@ impl Client {
             .http_client
             .post(addr)
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", self.auth_token.expose_secret()))
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.auth_token.expose_secret()),
+            )
             .body(req_bytes)
             .timeout(timeout)
             .send()
@@ -344,7 +347,13 @@ mod tests {
     fn client_debug_redacts_auth_token() {
         let client = Client::new("http://localhost:9999", "super-secret-token").unwrap();
         let rendered = format!("{client:?}");
-        assert!(!rendered.contains("super-secret-token"), "token leaked in Debug: {rendered}");
-        assert!(rendered.contains("REDACTED"), "expected REDACTED marker in Debug: {rendered}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "token leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("REDACTED"),
+            "expected REDACTED marker in Debug: {rendered}"
+        );
     }
 }

--- a/crates/p2p/src/bootnode.rs
+++ b/crates/p2p/src/bootnode.rs
@@ -7,6 +7,7 @@ use libp2p::Multiaddr;
 use pluto_eth2util::enr::Record;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
+use url::Url;
 
 use crate::peer::{
     AddrInfo, MutablePeer, Peer, PeerError, addr_infos_from_p2p_addrs, peer_id_from_key,
@@ -159,6 +160,21 @@ pub async fn new_relays(
     Ok(resp)
 }
 
+/// Strips embedded userinfo (basic-auth credentials) from a URL string before
+/// it is passed to a log field so tokens and passwords cannot appear in logs.
+fn redact_url(raw: &str) -> String {
+    let Ok(mut url) = Url::parse(raw) else {
+        return raw.to_owned();
+    };
+    if url.username().is_empty() && url.password().is_none() {
+        return raw.to_owned();
+    }
+    if url.set_username("").is_err() || url.set_password(None).is_err() {
+        return "<redacted>".to_owned();
+    }
+    url.to_string()
+}
+
 /// Continuously resolves relay multiaddrs from an HTTP URL and updates the
 /// MutablePeer.
 ///
@@ -184,7 +200,7 @@ async fn resolve_relay(
         {
             Ok(addrs) => addrs,
             Err(e) => {
-                tracing::error!(err = %e, url = %raw_url, "Failed resolving relay addresses from URL");
+                tracing::error!(err = %e, url = %redact_url(&raw_url), "Failed resolving relay addresses from URL");
                 return;
             }
         };
@@ -208,7 +224,7 @@ async fn resolve_relay(
                     let peer = Peer::new_relay_peer(&infos[0]);
                     info!(
                         peer = %peer.name,
-                        url = %raw_url,
+                        url = %redact_url(&raw_url),
                         addrs = ?peer.addresses,
                         "Resolved new relay"
                     );
@@ -389,4 +405,30 @@ fn addr_info_from_p2p_addr(addr: &Multiaddr) -> std::result::Result<AddrInfo, Pe
     let mut infos = addr_infos_from_p2p_addrs(std::slice::from_ref(addr))?;
 
     infos.pop().ok_or(PeerError::MissingPeerIdInMultiaddr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_url;
+
+    #[test]
+    fn redact_url_strips_basic_auth_credentials() {
+        let raw = "https://user:s3cr3t@relay.example.com/path";
+        let result = redact_url(raw);
+        assert!(!result.contains("user"), "username leaked: {result}");
+        assert!(!result.contains("s3cr3t"), "password leaked: {result}");
+        assert!(result.contains("relay.example.com"), "host should remain: {result}");
+    }
+
+    #[test]
+    fn redact_url_is_noop_when_no_credentials() {
+        let raw = "https://relay.example.com/path";
+        assert_eq!(redact_url(raw), raw);
+    }
+
+    #[test]
+    fn redact_url_returns_original_for_unparseable_input() {
+        let raw = "not a url %%";
+        assert_eq!(redact_url(raw), raw);
+    }
 }

--- a/crates/p2p/src/bootnode.rs
+++ b/crates/p2p/src/bootnode.rs
@@ -7,7 +7,6 @@ use libp2p::Multiaddr;
 use pluto_eth2util::enr::Record;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-use url::Url;
 
 use crate::peer::{
     AddrInfo, MutablePeer, Peer, PeerError, addr_infos_from_p2p_addrs, peer_id_from_key,
@@ -160,21 +159,6 @@ pub async fn new_relays(
     Ok(resp)
 }
 
-/// Strips embedded userinfo (basic-auth credentials) from a URL string before
-/// it is passed to a log field so tokens and passwords cannot appear in logs.
-fn redact_url(raw: &str) -> String {
-    let Ok(mut url) = Url::parse(raw) else {
-        return raw.to_owned();
-    };
-    if url.username().is_empty() && url.password().is_none() {
-        return raw.to_owned();
-    }
-    if url.set_username("").is_err() || url.set_password(None).is_err() {
-        return "<redacted>".to_owned();
-    }
-    url.to_string()
-}
-
 /// Continuously resolves relay multiaddrs from an HTTP URL and updates the
 /// MutablePeer.
 ///
@@ -200,7 +184,7 @@ async fn resolve_relay(
         {
             Ok(addrs) => addrs,
             Err(e) => {
-                tracing::error!(err = %e, url = %redact_url(&raw_url), "Failed resolving relay addresses from URL");
+                tracing::error!(err = %e, url = %raw_url, "Failed resolving relay addresses from URL");
                 return;
             }
         };
@@ -224,7 +208,7 @@ async fn resolve_relay(
                     let peer = Peer::new_relay_peer(&infos[0]);
                     info!(
                         peer = %peer.name,
-                        url = %redact_url(&raw_url),
+                        url = %raw_url,
                         addrs = ?peer.addresses,
                         "Resolved new relay"
                     );
@@ -405,30 +389,4 @@ fn addr_info_from_p2p_addr(addr: &Multiaddr) -> std::result::Result<AddrInfo, Pe
     let mut infos = addr_infos_from_p2p_addrs(std::slice::from_ref(addr))?;
 
     infos.pop().ok_or(PeerError::MissingPeerIdInMultiaddr)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::redact_url;
-
-    #[test]
-    fn redact_url_strips_basic_auth_credentials() {
-        let raw = "https://user:s3cr3t@relay.example.com/path";
-        let result = redact_url(raw);
-        assert!(!result.contains("user"), "username leaked: {result}");
-        assert!(!result.contains("s3cr3t"), "password leaked: {result}");
-        assert!(result.contains("relay.example.com"), "host should remain: {result}");
-    }
-
-    #[test]
-    fn redact_url_is_noop_when_no_credentials() {
-        let raw = "https://relay.example.com/path";
-        assert_eq!(redact_url(raw), raw);
-    }
-
-    #[test]
-    fn redact_url_returns_original_for_unparseable_input() {
-        let raw = "not a url %%";
-        assert_eq!(redact_url(raw), raw);
-    }
 }


### PR DESCRIPTION
Closes #504

## Summary

- **`keymanager::Client`** (`eth2util`): stores bearer token as `Secret<String>` (secrecy crate). Derived `Debug` now prints `Secret([REDACTED])` instead of the raw value. `expose_secret()` is called only at the HTTP header construction site.
- **`KeymanagerConfig`** (`dkg`): replaces derived `Debug` with a manual impl that prints `<redacted>` for `auth_token`, following the existing `LokiConfig` pattern in the tracing crate. The field stays `String` so the `bon` builder API and CLI arg tests are unchanged.
- **`bootnode::resolve_relay`** (`p2p`): adds a `redact_url()` helper that strips embedded userinfo (basic-auth credentials) from relay URLs before they appear in tracing fields.

## Test plan

- [x] `cargo test -p pluto-eth2util -- keymanager` — `client_debug_redacts_auth_token` passes
- [x] `cargo test -p pluto-dkg -- keymanager` — `keymanager_config_debug_redacts_auth_token` passes
- [x] `cargo test -p pluto-p2p -- bootnode::tests` — all 3 `redact_url_*` tests pass