### PR TITLE
feat(app): wire the monitoring API into pluto run

### DIFF
--- a/crates/app/src/monitoringapi/checker.rs
+++ b/crates/app/src/monitoringapi/checker.rs
@@ -1,6 +1,10 @@
 //! Background readiness checker for `/readyz`.
 
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use chrono::{DateTime, Utc};
 use pluto_cluster::helpers;
@@ -45,14 +49,16 @@ struct ChainConfig {
 /// Starts the background readiness checker and returns the shared readiness
 /// state served by `/readyz`.
 ///
-/// `seen_pubkeys` should receive validator public keys observed through the
-/// validator API. `validator_api_calls` should receive one item for each
-/// validator API call. The checker consumes both receivers until cancellation.
+/// `seen_pubkeys` is a shared, deduped set of DV root pubkeys the validator
+/// client has referenced through the validator API; the checker drains it each
+/// slot, so it stays bounded by the validator count regardless of request
+/// volume. `validator_api_calls` should receive one item for each validator API
+/// call. The checker consumes both until cancellation.
 pub fn start_ready_checker(
     p2p_context: P2PContext,
     beacon_node: EthBeaconNodeApiClient,
     pubkeys: Vec<PubKey>,
-    seen_pubkeys: mpsc::Receiver<PubKey>,
+    seen_pubkeys: Arc<Mutex<HashSet<PubKey>>>,
     validator_api_calls: mpsc::Receiver<()>,
     ct: CancellationToken,
 ) -> ReadyState {
@@ -161,7 +167,7 @@ async fn run_ready_checker(
     p2p_context: P2PContext,
     beacon_node: EthBeaconNodeApiClient,
     pubkeys: Vec<PubKey>,
-    mut seen_pubkeys: mpsc::Receiver<PubKey>,
+    seen_pubkeys: Arc<Mutex<HashSet<PubKey>>>,
     mut validator_api_calls: mpsc::Receiver<()>,
     ct: CancellationToken,
     readiness: ReadyState,
@@ -184,7 +190,6 @@ async fn run_ready_checker(
     slot_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let mut peer_count_interval = tokio::time::interval(PEER_COUNT_PERIOD);
     peer_count_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    let mut seen_pubkeys_open = true;
     let mut validator_api_calls_open = true;
 
     slot_interval.tick().await;
@@ -206,6 +211,13 @@ async fn run_ready_checker(
                         None
                     }
                 };
+                // Fold in the pubkeys the VC referenced since the last tick.
+                // The set is deduped and drained every slot, so it stays
+                // bounded by the validator count regardless of request volume.
+                let observed = std::mem::take(&mut *seen_pubkeys.lock().expect("seen pubkeys mutex"));
+                for pubkey in observed {
+                    checker.observe_pubkey(pubkey);
+                }
                 let evaluated_epoch = current_epoch(&config, Utc::now());
                 let status = checker.evaluate_round(
                     quorum_peers_connected(&p2p_context),
@@ -216,12 +228,6 @@ async fn run_ready_checker(
                 match status {
                     Ok(()) => readiness.set_ready(),
                     Err(error) => readiness.set_error(error),
-                }
-            }
-            pubkey = seen_pubkeys.recv(), if seen_pubkeys_open => {
-                match pubkey {
-                    Some(pubkey) => checker.observe_pubkey(pubkey),
-                    None => seen_pubkeys_open = false,
                 }
             }
             call = validator_api_calls.recv(), if validator_api_calls_open => {

--- a/crates/app/src/monitoringapi/router.rs
+++ b/crates/app/src/monitoringapi/router.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 use axum::{
     Router,
     extract::State,
-    http::StatusCode,
+    http::{StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
     routing::get,
 };
+use vise::{Format, MetricsCollection};
 
 use super::readiness::{ReadinessCheck, ReadinessError};
 
@@ -41,12 +42,33 @@ pub fn router(checker: impl ReadinessCheck) -> Router {
     router_with_state(MonitoringState::new(checker))
 }
 
-/// Builds a monitoring API router from preconstructed state.
+/// Builds a monitoring API router from preconstructed state, serving Prometheus
+/// `/metrics` plus the `/livez` and `/readyz` probes.
 pub fn router_with_state(state: MonitoringState) -> Router {
     Router::new()
+        .route("/metrics", get(metrics))
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
         .with_state(state)
+}
+
+/// Serves the process metrics in the OpenMetrics-for-Prometheus text format —
+/// the same exposition the `vise-exporter` produces. Encodes the global `vise`
+/// registry on each scrape.
+async fn metrics() -> Response {
+    let registry = MetricsCollection::default().collect();
+    let mut buffer = String::new();
+    if let Err(error) = registry.encode(&mut buffer, Format::OpenMetricsForPrometheus) {
+        // Encoding the in-process registry should never fail; surface a 500
+        // rather than a partial body if it somehow does.
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to encode metrics: {error}"),
+        )
+            .into_response();
+    }
+
+    ([(CONTENT_TYPE, Format::OPEN_METRICS_CONTENT_TYPE)], buffer).into_response()
 }
 
 async fn livez() -> impl IntoResponse {
@@ -122,6 +144,46 @@ mod tests {
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(body, "beacon node down");
+    }
+
+    #[tokio::test]
+    async fn metrics_serves_prometheus_exposition() {
+        // Touch a monitoring gauge so the global `vise` registry is initialised
+        // and its series appears in the exposition.
+        crate::monitoringapi::MONITORING_METRICS
+            .monitoring_readyz
+            .set(1);
+
+        let request = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .expect("build request");
+        let response = router(ReadyState::new())
+            .oneshot(request)
+            .await
+            .expect("request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .expect("content-type header")
+            .to_str()
+            .expect("utf8 content-type")
+            .to_owned();
+        assert!(
+            content_type.contains("openmetrics-text"),
+            "unexpected content-type: {content_type}"
+        );
+
+        let body = to_bytes(response.into_body(), BODY_LIMIT)
+            .await
+            .expect("read body");
+        let body = String::from_utf8(body.to_vec()).expect("utf8 body");
+        assert!(
+            body.contains("app_monitoring_readyz"),
+            "metrics body missing readyz gauge: {body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/node/behaviour.rs
+++ b/crates/app/src/node/behaviour.rs
@@ -62,6 +62,9 @@ pub struct CoreHandles {
     pub parsigex: parsigex::Handle,
     /// Outbound QBFT broadcast handle.
     pub consensus: qbft::p2p::Handle,
+    /// Shared P2P runtime context (known peers + live connections), used by the
+    /// monitoring API's readiness checker to compute quorum connectivity.
+    pub p2p_context: P2PContext,
 }
 
 /// Composes the core behaviours and builds the libp2p [`Node`].
@@ -141,6 +144,10 @@ pub(crate) async fn wire_p2p(
     .with_peers(peer_ids.clone());
     let peerinfo_comp = peerinfo::Behaviour::new(local_peer_id, peerinfo_config);
 
+    // Clone the context before it is moved into the node so the readiness
+    // checker observes the same shared peer/connection state the swarm updates.
+    let p2p_context_for_handle = p2p_context.clone();
+
     let node = Node::new(
         p2p_config,
         key,
@@ -162,6 +169,7 @@ pub(crate) async fn wire_p2p(
     let handles = CoreHandles {
         parsigex: parsigex_handle,
         consensus: consensus_handle,
+        p2p_context: p2p_context_for_handle,
     };
 
     Ok((node, handles))

--- a/crates/app/src/node/config.rs
+++ b/crates/app/src/node/config.rs
@@ -8,11 +8,11 @@ use pluto_p2p::config::P2PConfig;
 /// Application configuration for running a distributed-validator node.
 ///
 /// This is the Rust analog of Charon's `app.Config` (`app/app.go`), reduced to
-/// the minimal set required to wire and run the core duty workflow.
-/// Observability (monitoring/debug API, tracing/OTLP) and simnet/mock-only
+/// the minimal set required to wire and run the core duty workflow plus the
+/// monitoring API. Debug/pprof API, OTLP/Jaeger tracing and simnet/mock-only
 /// fields are intentionally omitted for the minimal-runnable wiring.
-// TODO(#402 part B): add monitoring/debug addrs, OTLP/Jaeger tracing config,
-// simnet (beacon/validator mock) and `TestConfig`-style overrides.
+// TODO(#402 part B): add debug/pprof addr, OTLP/Jaeger tracing config, simnet
+// (beacon/validator mock) and `TestConfig`-style overrides.
 #[derive(Debug, Clone)]
 pub struct AppConfig {
     /// P2P networking configuration (listen/advertise addresses, relays, ...).
@@ -41,6 +41,11 @@ pub struct AppConfig {
 
     /// Address the validator API HTTP server binds to.
     pub validator_api_addr: SocketAddr,
+
+    /// Address the monitoring API HTTP server binds to. Serves the Prometheus
+    /// `/metrics` scrape endpoint plus the `/livez` and `/readyz` health
+    /// probes.
+    pub monitoring_addr: SocketAddr,
 
     /// Whether the builder API (MEV-boost) is enabled.
     pub builder_api: bool,

--- a/crates/app/src/node/mod.rs
+++ b/crates/app/src/node/mod.rs
@@ -25,8 +25,8 @@ pub mod wire;
 pub use config::AppConfig;
 
 use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock},
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use futures::StreamExt;
@@ -391,6 +391,21 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
     // `eth2_cl` is moved into the workflow inputs below.
     let monitoring_beacon = eth2_cl.clone();
 
+    // Readiness observes which DV root pubkeys the validator client references
+    // on the validator API, so `/readyz` can tell whether the VC is exercising
+    // every validator. A deduped set (not a channel) keeps this bounded by the
+    // validator count on the request path: repeated validator-API calls just
+    // re-insert, and the ready checker drains the set each slot.
+    let seen_pubkeys: Arc<Mutex<HashSet<PubKey>>> = Arc::new(Mutex::new(HashSet::new()));
+    let seen_pubkeys_observer: pluto_core::validatorapi::SeenPubkeysFn = {
+        let seen_pubkeys = Arc::clone(&seen_pubkeys);
+        Arc::new(move |pubkey: PubKey| {
+            if let Ok(mut set) = seen_pubkeys.lock() {
+                set.insert(pubkey);
+            }
+        })
+    };
+
     let wired = wire::wire_core_workflow(
         WireInputs {
             threshold,
@@ -408,6 +423,7 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
             graffiti_builder,
             electra_slot,
             fetch_only_comm_idx0,
+            seen_pubkeys: Some(seen_pubkeys_observer),
         },
         ct.clone(),
     )
@@ -428,6 +444,7 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
             num_validators,
             num_peers,
             quorum_peers,
+            seen_pubkeys,
         },
         ct,
     )
@@ -449,6 +466,9 @@ struct MonitoringInputs {
     num_peers: i64,
     /// Peers required for quorum (health-checker metadata).
     quorum_peers: i64,
+    /// Shared, deduped set of DV root pubkeys observed on the validator API,
+    /// drained each slot by the readiness checker.
+    seen_pubkeys: Arc<Mutex<HashSet<PubKey>>>,
 }
 
 /// Builds the production parsigex seam from the real `parsigex::Handle`.
@@ -561,27 +581,21 @@ async fn run_lifecycle(
         num_validators,
         num_peers,
         quorum_peers,
+        seen_pubkeys,
     } = monitoring;
 
     // Every validator-API request feeds the readiness checker's "vc connected"
     // signal. Non-blocking sends drop when the buffer is full.
     let (vapi_calls_tx, vapi_calls_rx) = tokio::sync::mpsc::channel::<()>(VAPI_CALLS_BUFFER);
 
-    // The seen-pubkeys readiness signal is deferred: pluto's
-    // `validatorapi::Component` does not yet surface the pubkeys a VC queries.
-    // The sender is parked so the channel stays open (the checker keeps polling
-    // it) but never delivers, leaving readiness reporting "vc missing
-    // validators" until the signal is wired. No smoke-test alert depends on
-    // `/readyz`.
-    // TODO: surface observed pubkeys from `validatorapi::Component` and feed
-    // them here.
-    let (_seen_pubkeys_tx, seen_pubkeys_rx) = tokio::sync::mpsc::channel::<PubKey>(1);
-
+    // `seen_pubkeys` collects the DV root pubkeys the validator client
+    // references on the validator API (via the component's observer); the
+    // checker drains it each slot so readiness knows every validator is served.
     let readiness = monitoringapi::start_ready_checker(
         handles.p2p_context.clone(),
         monitoring_beacon,
         monitoring_pubkeys,
-        seen_pubkeys_rx,
+        seen_pubkeys,
         vapi_calls_rx,
         ct.clone(),
     );

--- a/crates/app/src/node/mod.rs
+++ b/crates/app/src/node/mod.rs
@@ -37,9 +37,15 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use behaviour::{CoreBehaviour, CoreHandles};
+use pluto_core::types::PubKey;
 use wire::{ParSigExSeam, ValidatorInfo, WireInputs, WiredComponents};
 
-use crate::privkeylock;
+use crate::{health, monitoringapi, privkeylock};
+
+/// Buffer for the validator-API-call channel feeding the readiness checker.
+/// Sends are non-blocking (dropped when full): the checker only needs to
+/// observe that calls happened, not count every one exactly.
+const VAPI_CALLS_BUFFER: usize = 128;
 
 /// Errors raised while constructing or running a distributed-validator node.
 #[derive(Debug, thiserror::Error)]
@@ -147,6 +153,10 @@ pub enum AppError {
     /// Validator API server failed.
     #[error("validator api: {0}")]
     ValidatorApi(#[source] std::io::Error),
+
+    /// Monitoring API server failed.
+    #[error("monitoring api: {0}")]
+    MonitoringApi(#[source] std::io::Error),
 }
 
 /// A wired, runnable distributed-validator node.
@@ -212,6 +222,14 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
     let peers = lock.peers()?;
     pluto_p2p::peer::verify_p2p_key(&peers, &key)?;
 
+    // Cluster size + quorum for the health-checker metadata, captured before
+    // `peers` is moved into the P2P wiring.
+    let num_peers = i64::try_from(peers.len()).unwrap_or(i64::MAX);
+    let quorum_peers = i64::try_from(pluto_cluster::helpers::threshold(
+        u64::try_from(peers.len()).unwrap_or(u64::MAX),
+    ))
+    .unwrap_or(i64::MAX);
+
     let local_peer_id = pluto_p2p::peer::peer_id_from_key(key.public_key())?;
     let local_node = peers
         .iter()
@@ -225,6 +243,11 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
 
     // Per-validator data for this node (mirrors app.go:415-452).
     let validators = build_validators(&lock, share_idx)?;
+
+    // DV root pubkeys + count for the monitoring readiness + health checkers,
+    // captured before `validators` is moved into the core-workflow wiring.
+    let monitoring_pubkeys: Vec<PubKey> = validators.iter().map(|v| v.pubkey).collect();
+    let num_validators = validators.len();
 
     // ---- (2/3) eth2 clients ----
     //
@@ -364,6 +387,10 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
     // against the beacon-node signing domain.
     let sigagg_verifier = pluto_core::sigagg::new_verifier(Arc::new(eth2_cl.clone()));
 
+    // The readiness checker uses its own beacon-client clone, taken before
+    // `eth2_cl` is moved into the workflow inputs below.
+    let monitoring_beacon = eth2_cl.clone();
+
     let wired = wire::wire_core_workflow(
         WireInputs {
             threshold,
@@ -394,9 +421,34 @@ async fn run(config: AppConfig, ct: CancellationToken) -> Result<(), AppError> {
         wired,
         priv_key_lock,
         config.validator_api_addr,
+        MonitoringInputs {
+            addr: config.monitoring_addr,
+            beacon_node: monitoring_beacon,
+            pubkeys: monitoring_pubkeys,
+            num_validators,
+            num_peers,
+            quorum_peers,
+        },
         ct,
     )
     .await
+}
+
+/// Inputs for wiring the monitoring API: the listen address plus everything the
+/// readiness and health checkers need.
+struct MonitoringInputs {
+    /// Address the monitoring HTTP server binds to.
+    addr: std::net::SocketAddr,
+    /// Beacon client the readiness checker queries for sync/peer/version state.
+    beacon_node: pluto_eth2api::EthBeaconNodeApiClient,
+    /// DV root public keys tracked by the readiness checker.
+    pubkeys: Vec<PubKey>,
+    /// Number of validators (health-checker cardinality + metadata).
+    num_validators: usize,
+    /// Number of cluster peers (health-checker metadata).
+    num_peers: i64,
+    /// Peers required for quorum (health-checker metadata).
+    quorum_peers: i64,
 }
 
 /// Builds the production parsigex seam from the real `parsigex::Handle`.
@@ -430,13 +482,18 @@ fn production_parsigex_seam(handles: &CoreHandles) -> ParSigExSeam {
 
 /// Spawns and supervises the node's long-lived tasks, then performs an ordered
 /// shutdown on cancellation or first-task failure.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "aggregates independent long-lived inputs (swarm, consensus, wired components, monitoring); a single config struct would just move the coupling"
+)]
 async fn run_lifecycle(
     node: pluto_p2p::p2p::Node<CoreBehaviour>,
     consensus: Arc<qbft::Consensus>,
-    _handles: CoreHandles,
+    handles: CoreHandles,
     wired: WiredComponents,
     priv_key_lock: Option<Arc<privkeylock::Service>>,
     validator_api_addr: std::net::SocketAddr,
+    monitoring: MonitoringInputs,
     ct: CancellationToken,
 ) -> Result<(), AppError> {
     let WiredComponents {
@@ -492,10 +549,82 @@ async fn run_lifecycle(
         tasks.spawn(async move { svc.run().await.map_err(AppError::PrivKeyLock) });
     }
 
-    // Validator API axum server.
+    // ---- Monitoring API ----
+    //
+    // Serves Prometheus `/metrics`, `/livez` and `/readyz` on the monitoring
+    // address (backed by the readiness checker), and runs the health checker
+    // that publishes `app_health_checks`.
+    let MonitoringInputs {
+        addr: monitoring_addr,
+        beacon_node: monitoring_beacon,
+        pubkeys: monitoring_pubkeys,
+        num_validators,
+        num_peers,
+        quorum_peers,
+    } = monitoring;
+
+    // Every validator-API request feeds the readiness checker's "vc connected"
+    // signal. Non-blocking sends drop when the buffer is full.
+    let (vapi_calls_tx, vapi_calls_rx) = tokio::sync::mpsc::channel::<()>(VAPI_CALLS_BUFFER);
+
+    // The seen-pubkeys readiness signal is deferred: pluto's
+    // `validatorapi::Component` does not yet surface the pubkeys a VC queries.
+    // The sender is parked so the channel stays open (the checker keeps polling
+    // it) but never delivers, leaving readiness reporting "vc missing
+    // validators" until the signal is wired. No smoke-test alert depends on
+    // `/readyz`.
+    // TODO: surface observed pubkeys from `validatorapi::Component` and feed
+    // them here.
+    let (_seen_pubkeys_tx, seen_pubkeys_rx) = tokio::sync::mpsc::channel::<PubKey>(1);
+
+    let readiness = monitoringapi::start_ready_checker(
+        handles.p2p_context.clone(),
+        monitoring_beacon,
+        monitoring_pubkeys,
+        seen_pubkeys_rx,
+        vapi_calls_rx,
+        ct.clone(),
+    );
+
+    // Health checker: periodic metric scrapes → `app_health_checks` gauge.
+    {
+        let ct = ct.clone();
+        let checker = health::Checker::new(
+            health::Metadata {
+                num_validators: i64::try_from(num_validators).unwrap_or(i64::MAX),
+                num_peers,
+                quorum_peers,
+            },
+            Box::new(health::ViseGatherer),
+            num_validators,
+        );
+        tasks.spawn(async move {
+            checker.run(ct).await;
+            Ok(())
+        });
+    }
+
+    // Validator API axum server. Each request bumps the readiness "vc
+    // connected" counter via middleware.
+    let validator_api_router = validator_api_router.layer(axum::middleware::from_fn(
+        move |request: axum::extract::Request, next: axum::middleware::Next| {
+            let vapi_calls = vapi_calls_tx.clone();
+            async move {
+                let _ = vapi_calls.try_send(());
+                next.run(request).await
+            }
+        },
+    ));
     tasks.spawn(serve_validator_api(
         validator_api_addr,
         validator_api_router,
+        ct.clone(),
+    ));
+
+    // Monitoring HTTP server (metrics + livez + readyz).
+    tasks.spawn(serve_monitoring_api(
+        monitoring_addr,
+        monitoringapi::router_with_state(monitoringapi::MonitoringState::new(readiness)),
         ct.clone(),
     ));
 
@@ -542,22 +671,41 @@ async fn run_lifecycle(
     task_err.map_or(Ok(()), Err)
 }
 
-/// Serves the validator API until `ct` fires (graceful shutdown, `Ok`). A bind
-/// or serve failure is returned and fails the run, matching Charon's
-/// `httpServeHook`, which swallows only `http.ErrServerClosed`.
+/// Serves an HTTP `router` on `addr` until `ct` fires. Graceful shutdown on
+/// cancellation is a clean exit (`Ok`); a bind or serve failure is mapped via
+/// `wrap_err` and fails the run.
+async fn serve_http(
+    addr: std::net::SocketAddr,
+    router: axum::Router,
+    ct: CancellationToken,
+    wrap_err: fn(std::io::Error) -> AppError,
+) -> Result<(), AppError> {
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(wrap_err)?;
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move { ct.cancelled().await })
+        .await
+        .map_err(wrap_err)
+}
+
+/// Serves the validator API (see [`serve_http`]).
 async fn serve_validator_api(
     addr: std::net::SocketAddr,
     router: axum::Router,
     ct: CancellationToken,
 ) -> Result<(), AppError> {
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .map_err(AppError::ValidatorApi)?;
+    serve_http(addr, router, ct, AppError::ValidatorApi).await
+}
 
-    axum::serve(listener, router)
-        .with_graceful_shutdown(async move { ct.cancelled().await })
-        .await
-        .map_err(AppError::ValidatorApi)
+/// Serves the monitoring API (see [`serve_http`]).
+async fn serve_monitoring_api(
+    addr: std::net::SocketAddr,
+    router: axum::Router,
+    ct: CancellationToken,
+) -> Result<(), AppError> {
+    serve_http(addr, router, ct, AppError::MonitoringApi).await
 }
 
 /// Drives the libp2p swarm. Routing is push-based inside the behaviours, so the
@@ -717,5 +865,102 @@ mod tests {
         )
         .await
         .expect("cancelled serve should exit cleanly");
+    }
+
+    // A failed monitoring-API bind must fail the run too, tagged as a
+    // monitoring (not validator API) error.
+    #[tokio::test]
+    async fn serve_monitoring_api_maps_bind_failure() {
+        let occupied = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let addr = occupied.local_addr().expect("local addr");
+
+        let err = serve_monitoring_api(addr, axum::Router::new(), CancellationToken::new())
+            .await
+            .expect_err("bind on an occupied port should fail");
+
+        assert!(matches!(err, AppError::MonitoringApi(_)));
+    }
+
+    // End-to-end: the wired monitoring server actually serves `/metrics`,
+    // `/livez` and `/readyz` over real TCP — the path Prometheus scrapes.
+    #[tokio::test]
+    async fn monitoring_server_serves_all_routes_over_tcp() {
+        // Reserve an ephemeral port, then release it so the server can bind it.
+        let addr = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind ephemeral port");
+            listener.local_addr().expect("local addr")
+        };
+
+        // A ready readiness state so `/readyz` returns 200, and a touched gauge
+        // so `/metrics` has a series to expose.
+        monitoringapi::MONITORING_METRICS.monitoring_readyz.set(1);
+        let router = monitoringapi::router_with_state(monitoringapi::MonitoringState::new(
+            monitoringapi::ReadyState::ready(),
+        ));
+
+        let ct = CancellationToken::new();
+        let server = tokio::spawn(serve_monitoring_api(addr, router, ct.clone()));
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .expect("build client");
+        let base = format!("http://{addr}");
+
+        // Poll `/livez` until the server accepts connections (bounded).
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let livez = loop {
+            match client.get(format!("{base}/livez")).send().await {
+                Ok(response) => break response,
+                Err(_) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "monitoring server never came up"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        };
+        assert_eq!(livez.status(), reqwest::StatusCode::OK);
+        assert_eq!(livez.text().await.expect("livez body"), "ok");
+
+        let readyz = client
+            .get(format!("{base}/readyz"))
+            .send()
+            .await
+            .expect("readyz request");
+        assert_eq!(readyz.status(), reqwest::StatusCode::OK);
+
+        let metrics = client
+            .get(format!("{base}/metrics"))
+            .send()
+            .await
+            .expect("metrics request");
+        assert_eq!(metrics.status(), reqwest::StatusCode::OK);
+        let content_type = metrics
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_owned();
+        assert!(
+            content_type.contains("openmetrics-text"),
+            "unexpected content-type: {content_type}"
+        );
+        assert!(
+            metrics
+                .text()
+                .await
+                .expect("metrics body")
+                .contains("app_monitoring_readyz"),
+            "metrics exposition missing readyz gauge"
+        );
+
+        ct.cancel();
+        let _ = server.await;
     }
 }

--- a/crates/app/src/node/wire.rs
+++ b/crates/app/src/node/wire.rs
@@ -39,7 +39,7 @@ use pluto_core::{
     signeddata::{SyncContribution, VersionedAggregatedAttestation},
     types::{Duty, ParSignedData, ParSignedDataSet, PubKey, SignedData, SignedDataSet},
     unsigneddata::{self, UnsignedDataSet},
-    validatorapi::{self, Component, Handler},
+    validatorapi::{self, Component, Handler, SeenPubkeysFn},
 };
 use pluto_eth2api::{
     BeaconNodeClient, EthBeaconNodeApiClient,
@@ -144,6 +144,10 @@ pub struct WireInputs {
     /// Whether to fetch only committee index 0 at/after `electra_slot`
     /// (`Feature::FetchOnlyCommIdx0`).
     pub fetch_only_comm_idx0: bool,
+    /// Observer invoked with each DV root pubkey the validator client
+    /// references on the validator API, feeding the monitoring readiness
+    /// checker. `None` disables the signal (e.g. tests).
+    pub seen_pubkeys: Option<SeenPubkeysFn>,
 }
 
 /// The wired components and long-lived handles produced by
@@ -197,6 +201,7 @@ pub async fn wire_core_workflow(
         graffiti_builder,
         electra_slot,
         fetch_only_comm_idx0,
+        seen_pubkeys,
     } = inputs;
 
     // ---- Derived validator maps (mirrors app.go:407-452) ----
@@ -586,6 +591,11 @@ pub async fn wire_core_workflow(
                     .map_err(Into::into)
             }
         });
+    }
+
+    // Feed the monitoring readiness checker the pubkeys the VC references.
+    if let Some(observer) = seen_pubkeys {
+        vapi.register_seen_pubkeys(observer);
     }
 
     let validator_api_router = validatorapi::new_router(

--- a/crates/app/tests/wiring.rs
+++ b/crates/app/tests/wiring.rs
@@ -232,6 +232,7 @@ fn wire_inputs_with(
         graffiti_builder: pluto_core::fetcher::GraffitiBuilder::default(),
         electra_slot: 0,
         fetch_only_comm_idx0: false,
+        seen_pubkeys: None,
     }
 }
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -21,9 +21,11 @@
 //! Not every accepted flag is honored yet. Correctness-affecting flags with no
 //! implementation (simnet mocks, custom testnets, beacon-node headers, VC TLS,
 //! a preferred consensus protocol, synthetic block proposals) fail fast with a
-//! "not yet supported" error, while observability/availability-only flags
-//! (monitoring/debug addresses, OTLP, proc directory, fallback beacon
-//! endpoints) are ignored with a warning.
+//! "not yet supported" error, while the remaining observability/availability
+//! flags with no implementation (debug/pprof address, OTLP, proc directory,
+//! fallback beacon endpoints) are ignored with a warning. The monitoring API
+//! (`--monitoring-address`) is wired: the node serves Prometheus `/metrics`
+//! plus `/livez` and `/readyz` there.
 //!
 //! Limitations:
 //! - `--log-format` and `--log-output-path` are accepted but not yet applied
@@ -58,8 +60,7 @@ const MAX_GRAFFITI_BYTES_NO_APPEND: usize = 32;
 const MAX_NICKNAME_BYTES: usize = 32;
 /// Grace period for the Loki background task to flush buffered logs on exit.
 const LOKI_FLUSH_TIMEOUT: StdDuration = StdDuration::from_secs(3);
-/// Default `--monitoring-address`; shared by the flag definition and the
-/// ignored-flag warning so they cannot drift.
+/// Default `--monitoring-address`.
 const DEFAULT_MONITORING_ADDR: &str = "127.0.0.1:3620";
 /// Default `--simnet-validator-keys-dir`; shared by the flag definition and
 /// the unsupported-flag check so they cannot drift.
@@ -973,7 +974,9 @@ fn build_app_config(config: RunConfig) -> Result<pluto_app::node::AppConfig> {
     warn_ignored_flags(&config);
 
     let feature_set = build_feature_set(&config.feature)?;
-    let validator_api_addr = parse_validator_api_addr(&config.validator_api_addr)?;
+    let validator_api_addr =
+        parse_socket_addr("validator-api-address", &config.validator_api_addr)?;
+    let monitoring_addr = parse_socket_addr("monitoring-address", &config.monitoring_addr)?;
 
     // Exhaustive destructure: adding a `RunConfig` field without deciding its
     // bridge behavior fails to compile instead of being silently dropped.
@@ -1028,6 +1031,7 @@ fn build_app_config(config: RunConfig) -> Result<pluto_app::node::AppConfig> {
         beacon_node_timeout,
         beacon_node_submit_timeout,
         validator_api_addr,
+        monitoring_addr,
         builder_api,
         nickname,
         no_verify,
@@ -1090,12 +1094,6 @@ fn check_unsupported_flags(config: &RunConfig) -> Result<()> {
 /// Warns about observability/availability-only flags the run workflow ignores.
 /// Runs after tracing init (see [`run`]) so the warnings reach the subscriber.
 fn warn_ignored_flags(config: &RunConfig) {
-    if config.monitoring_addr != DEFAULT_MONITORING_ADDR {
-        warn!(
-            address = %config.monitoring_addr,
-            "the monitoring API is not yet supported by pluto run; ignoring --monitoring-address"
-        );
-    }
     if !config.debug_addr.is_empty() {
         warn!(
             address = %config.debug_addr,
@@ -1167,18 +1165,14 @@ fn build_feature_set(feature: &FeatureConfig) -> Result<Arc<FeatureSet>> {
     Ok(Arc::new(feature_set))
 }
 
-/// Parses the validator API listen address. Unlike a plain [`SocketAddr`]
-/// parse, [`ToSocketAddrs`] also resolves hostnames like `localhost:3600`,
-/// which Charon accepts (it defers to Go's `net.Listen`).
-fn parse_validator_api_addr(addr: &str) -> Result<SocketAddr> {
+/// Parses an HTTP listen address flag (`flag` names it for errors). Unlike a
+/// plain [`SocketAddr`] parse, [`ToSocketAddrs`] also resolves hostnames like
+/// `localhost:3600`, not just literal IPs.
+fn parse_socket_addr(flag: &str, addr: &str) -> Result<SocketAddr> {
     addr.to_socket_addrs()
-        .map_err(|err| CliError::Other(format!("invalid validator-api-address {addr:?}: {err}")))?
+        .map_err(|err| CliError::Other(format!("invalid {flag} {addr:?}: {err}")))?
         .next()
-        .ok_or_else(|| {
-            CliError::Other(format!(
-                "invalid validator-api-address {addr:?}: no addresses resolved"
-            ))
-        })
+        .ok_or_else(|| CliError::Other(format!("invalid {flag} {addr:?}: no addresses resolved")))
 }
 
 #[cfg(test)]
@@ -1880,13 +1874,36 @@ mod tests {
     fn build_app_config_ignores_observability_flags() {
         // Warn-and-continue: none of these may fail the bridge.
         app_config(&[
-            "--monitoring-address=127.0.0.1:9620",
             "--debug-address=127.0.0.1:9630",
             "--otlp-address=http://otlp.test:4317",
             "--proc-directory=/proc",
             "--fallback-beacon-node-endpoints=http://c.node",
         ])
         .expect("observability flags are ignored, not rejected");
+    }
+
+    #[test]
+    fn build_app_config_maps_monitoring_addr() {
+        // `--monitoring-address` is honored (the node serves /metrics, /livez
+        // and /readyz there), not ignored.
+        let config =
+            app_config(&["--monitoring-address=127.0.0.1:9620"]).expect("bridge should succeed");
+        assert_eq!(
+            config.monitoring_addr,
+            "127.0.0.1:9620".parse::<SocketAddr>().expect("socket addr")
+        );
+
+        // Default port when the flag is omitted.
+        let config = app_config(&[]).expect("bridge should succeed on defaults");
+        assert_eq!(
+            config.monitoring_addr,
+            "127.0.0.1:3620".parse::<SocketAddr>().expect("socket addr")
+        );
+
+        // Hostnames resolve, matching the validator-API address behaviour.
+        let config =
+            app_config(&["--monitoring-address=localhost:3620"]).expect("hostname resolves");
+        assert_eq!(config.monitoring_addr.port(), 3620);
     }
 
     #[test]

--- a/crates/core/src/validatorapi/component.rs
+++ b/crates/core/src/validatorapi/component.rs
@@ -126,6 +126,11 @@ pub type PubKeyByAttFn = Arc<
         + 'static,
 >;
 
+/// Observer invoked with each DV root public key a validator client references
+/// on a validator-facing endpoint (duties, validators). Lets the monitoring
+/// readiness checker track which validators the VC is actively serving.
+pub type SeenPubkeysFn = Arc<dyn Fn(PubKey) + Send + Sync + 'static>;
+
 /// Hard deadline for upstream beacon-node calls. Bounds the worst-case
 /// handler latency when the upstream hangs or stalls.
 const UPSTREAM_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -196,6 +201,9 @@ pub struct Component {
     duty_def_fn: Option<DutyDefFn>,
     /// Looks up the root pubkey for an `(slot, commIdx, valIdx)` triple.
     pub_key_by_att_fn: Option<PubKeyByAttFn>,
+    /// Invoked with each DV root pubkey the VC references on a validator-facing
+    /// endpoint, feeding the monitoring readiness "validators seen" signal.
+    seen_pubkeys: Option<SeenPubkeysFn>,
 }
 
 impl Component {
@@ -223,6 +231,7 @@ impl Component {
             await_agg_sig_db_fn: None,
             duty_def_fn: None,
             pub_key_by_att_fn: None,
+            seen_pubkeys: None,
         }
     }
 
@@ -252,6 +261,7 @@ impl Component {
             await_agg_sig_db_fn: None,
             duty_def_fn: None,
             pub_key_by_att_fn: None,
+            seen_pubkeys: None,
         }
     }
 
@@ -350,6 +360,39 @@ impl Component {
         self.pub_key_by_att_fn = Some(Arc::new(move |slot, comm, val| {
             Box::pin(f(slot, comm, val))
         }));
+    }
+
+    /// Registers (and overwrites any prior) seen-pubkeys observer. Invoked with
+    /// each of this cluster's DV root public keys as the validator client
+    /// references them on a validator-facing endpoint.
+    pub fn register_seen_pubkeys(&mut self, observer: SeenPubkeysFn) {
+        self.seen_pubkeys = Some(observer);
+    }
+
+    /// Reports a single cluster DV root pubkey to the registered seen-pubkeys
+    /// observer (no-op when unset).
+    fn observe_root_pubkey(&self, root: &BLSPubKey) {
+        if let Some(observer) = self.seen_pubkeys.as_deref() {
+            observer(PubKey::new(*root));
+        }
+    }
+
+    /// Reports each of our DV root public keys present in `pubkeys` to the
+    /// registered seen-pubkeys observer (no-op when unset). Unparseable or
+    /// non-cluster pubkeys are skipped — the surrounding rewrite validates
+    /// them.
+    fn observe_seen_pubkeys<'a>(&self, pubkeys: impl IntoIterator<Item = &'a str>) {
+        if self.seen_pubkeys.is_none() {
+            return;
+        }
+        for raw in pubkeys {
+            let Ok(pubkey) = parse_bls_pubkey(raw) else {
+                continue;
+            };
+            if self.pub_share_by_pubkey.contains_key(&pubkey) {
+                self.observe_root_pubkey(&pubkey);
+            }
+        }
     }
 
     /// Verifies an outer partial signature on a [`ParSignedData`] against
@@ -900,6 +943,7 @@ impl Handler for Component {
             }
         };
 
+        self.observe_seen_pubkeys(payload.data.iter().map(|duty| duty.pubkey.as_str()));
         swap_proposer_pubshares(&mut payload.data, &self.pub_share_by_pubkey)?;
 
         Ok(payload)
@@ -949,6 +993,7 @@ impl Handler for Component {
             }
         };
 
+        self.observe_seen_pubkeys(payload.data.iter().map(|duty| duty.pubkey.as_str()));
         swap_attester_pubshares(&mut payload.data, &self.pub_share_by_pubkey)?;
 
         Ok(payload)
@@ -1001,6 +1046,7 @@ impl Handler for Component {
             }
         };
 
+        self.observe_seen_pubkeys(payload.data.iter().map(|duty| duty.pubkey.as_str()));
         swap_sync_committee_pubshares(&mut payload.data, &self.pub_share_by_pubkey)?;
 
         Ok(payload)
@@ -1570,6 +1616,11 @@ impl Handler for Component {
                     "unknown validator public key in request",
                 )
             })?;
+            // Mark the validator seen as soon as its share resolves to a cluster
+            // root — before the upstream call — so a validator the beacon node
+            // has no row for yet (e.g. not activated) still counts toward
+            // readiness.
+            self.observe_root_pubkey(root);
             root_pubkeys.push(format_bls_pubkey(root));
         }
 
@@ -1627,6 +1678,12 @@ impl Handler for Component {
         // an unfiltered "fetch all"), validators outside the share map pass
         // through with their root pubkey untouched.
         let ignore_not_found = opts.indices.is_empty();
+        self.observe_seen_pubkeys(
+            payload
+                .data
+                .iter()
+                .map(|validator| validator.validator.pubkey.as_str()),
+        );
         let data = convert_validators(payload.data, &self.pub_share_by_pubkey, ignore_not_found)?;
 
         Ok(EthResponse {
@@ -6186,6 +6243,108 @@ mod tests {
         );
     }
 
+    /// A registered seen-pubkeys observer receives the DV root pubkey for each
+    /// cluster validator the VC references (and skips validators this cluster
+    /// does not own). This feeds `/readyz`'s "validators seen" state, which
+    /// otherwise sticks at "vc missing validators" after an epoch rollover.
+    #[tokio::test]
+    async fn validators_reports_seen_cluster_root_pubkeys() {
+        let server = MockServer::start().await;
+        let known_root = [0x11_u8; 48];
+        let share = [0x22_u8; 48];
+        let stranger = [0x33_u8; 48];
+        let body = GetStateValidatorsResponseResponse {
+            data: vec![
+                make_validator_datum(1, &known_root),
+                make_validator_datum(2, &stranger),
+            ],
+            execution_optimistic: false,
+            finalized: true,
+        };
+        Mock::given(method("POST"))
+            .and(path("/eth/v1/beacon/states/head/validators"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut component =
+            make_component_with_upstream(&server, HashMap::from([(known_root, share)]));
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        component.register_seen_pubkeys(Arc::new(move |pubkey| {
+            sink.lock().expect("seen lock").push(pubkey);
+        }));
+
+        component
+            .validators(ValidatorsOpts {
+                state: "head".to_owned(),
+                pubkeys: vec![share],
+                indices: vec![],
+            })
+            .await
+            .unwrap();
+
+        // The cluster-owned validator's root pubkey is reported (via both the
+        // share→root request translation and the response rewrite — production
+        // dedups these in a set); the stranger the cluster does not own is
+        // never reported.
+        let observed: std::collections::HashSet<PubKey> =
+            seen.lock().expect("seen lock").iter().copied().collect();
+        assert_eq!(
+            observed,
+            std::collections::HashSet::from([PubKey::new(known_root)])
+        );
+    }
+
+    /// Regression: a requested share resolves to a cluster root even when the
+    /// beacon node returns no validator row for it (e.g. not yet activated).
+    /// The root must still be marked seen — from the share→root translation —
+    /// so `/readyz` does not stick at "vc missing validators".
+    #[tokio::test]
+    async fn validators_reports_seen_pubkey_when_upstream_returns_no_rows() {
+        let server = MockServer::start().await;
+        let known_root = [0x44_u8; 48];
+        let share = [0x55_u8; 48];
+        let body = GetStateValidatorsResponseResponse {
+            // The beacon node has no row for the requested validator yet.
+            data: vec![],
+            execution_optimistic: false,
+            finalized: true,
+        };
+        Mock::given(method("POST"))
+            .and(path("/eth/v1/beacon/states/head/validators"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut component =
+            make_component_with_upstream(&server, HashMap::from([(known_root, share)]));
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        component.register_seen_pubkeys(Arc::new(move |pubkey| {
+            sink.lock().expect("seen lock").push(pubkey);
+        }));
+
+        let response = component
+            .validators(ValidatorsOpts {
+                state: "head".to_owned(),
+                pubkeys: vec![share],
+                indices: vec![],
+            })
+            .await
+            .unwrap();
+
+        // Empty upstream response, yet the requested validator's root is still
+        // reported seen via the share→root translation.
+        assert!(response.data.is_empty());
+        assert_eq!(
+            *seen.lock().expect("seen lock"),
+            vec![PubKey::new(known_root)]
+        );
+    }
+
     /// When the caller filters by index (any non-empty `indices`),
     /// `ignore_not_found` is `false`, so an upstream validator that does not
     /// belong to this cluster surfaces as `INTERNAL_SERVER_ERROR`.
@@ -6392,6 +6551,7 @@ mod tests {
             await_agg_sig_db_fn: None,
             duty_def_fn: None,
             pub_key_by_att_fn: None,
+            seen_pubkeys: None,
         };
         (component, mock)
     }

--- a/crates/core/src/validatorapi/mod.rs
+++ b/crates/core/src/validatorapi/mod.rs
@@ -13,7 +13,7 @@ pub mod types;
 #[cfg(test)]
 pub mod testutils;
 
-pub use component::Component;
+pub use component::{Component, SeenPubkeysFn};
 pub use error::ApiError;
 pub use handler::Handler;
 pub use router::new_router;


### PR DESCRIPTION
Stack on #536

  Wires the (already-ported) `monitoringapi` and `health` modules into the running node, so `pluto run` serves the monitoring API on `--monitoring-address` (default `127.0.0.1:3620`):

  - `GET /metrics` — Prometheus/OpenMetrics scrape of the global `vise` registry
  - `GET /livez` — liveness
  - `GET /readyz` — readiness, backed by a background checker (beacon-node sync/peers/version, quorum peer connectivity, validator-client activity)

  It also starts the health checker (`app_health_checks`). The CLI `run` bridge now honors `--monitoring-address` (previously accepted but ignored).

  Readiness's "validators seen" signal is fed from the validator API: `validatorapi::Component` gains a pubkey observer invoked at the share↔root translation points, collected into a bounded, deduped set  that the checker drains each slot.