### PR TITLE
fix: support custom testnet fork versions and charon-compatible CWD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,10 @@ FROM gcr.io/distroless/cc-debian13 AS app
 
 COPY --from=builder /usr/local/bin/pluto /app/bin/pluto
 
+# Match charon's working directory so that relative paths passed to flags such
+# as `--split-keys-dir` / `--cluster-dir` resolve under /opt/charon, keeping
+# pluto a drop-in replacement for charon. (The distroless base has no shell, so
+# WORKDIR is used to create the directory rather than a `RUN mkdir`.)
+WORKDIR /opt/charon
+
 ENTRYPOINT ["/app/bin/pluto"]

--- a/crates/cli/src/commands/create_cluster.rs
+++ b/crates/cli/src/commands/create_cluster.rs
@@ -373,17 +373,33 @@ pub async fn run(w: &mut dyn Write, mut args: CreateClusterArgs) -> CliResult<()
             return Err(CreateClusterError::MissingExecutionEngineAddress.into());
         };
 
+        // Register a fully-specified custom testnet (from `--testnet-*` flags)
+        // before verifying the definition. `load_definition` runs EIP-712
+        // signature verification, which looks the definition's fork version up
+        // in the supported-networks allowlist; a custom fork version would
+        // otherwise be rejected as "Invalid fork version". The flag-driven
+        // config path registers via `validate_network_config`, but that runs
+        // after this block, so we must register here too (registration is
+        // idempotent).
+        let testnet_network: network::Network = args.testnet_config.clone().into();
+        if testnet_network.is_non_zero() {
+            eth2util::network::add_test_network(testnet_network)?;
+        }
+
         let eth1cl = eth1wrap::EthClient::new(addr.clone()).await?;
         let def = load_definition(definition_file, &eth1cl).await?;
 
         args.nodes = u64::try_from(def.operators.len()).expect("operators length is too large");
         args.threshold = Some(def.threshold);
 
+        // Only map the fork version onto the built-in `Network` enum for known
+        // networks. A custom testnet has no enum variant; it is already
+        // registered above and is validated via `testnet_config`, so leave
+        // `args.network` unset in that case.
         let network_name = eth2util::network::fork_version_to_network(&def.fork_version)?;
-        args.network = Some(
-            Network::try_from(network_name.as_str())
-                .map_err(CreateClusterError::InvalidNetworkConfig)?,
-        );
+        if let Ok(network) = Network::try_from(network_name.as_str()) {
+            args.network = Some(network);
+        }
 
         definition_input = Some((def, eth1cl));
     }

--- a/crates/eth2util/src/network.rs
+++ b/crates/eth2util/src/network.rs
@@ -144,11 +144,25 @@ static SUPPORTED_NETWORKS: LazyLock<RwLock<Vec<Network>>> = LazyLock::new(|| {
 });
 
 /// Add a test network to the supported networks.
+///
+/// Registration is idempotent: if a network with the same genesis fork version
+/// is already registered the call is a no-op, so callers on different code
+/// paths (e.g. flag-driven registration and definition verification) can each
+/// register the same custom testnet without creating duplicates.
 pub fn add_test_network(network: Network) -> Result<()> {
-    SUPPORTED_NETWORKS
+    let mut networks = SUPPORTED_NETWORKS
         .write()
-        .map_err(|_| NetworkError::FailedToWriteSupportedNetworks)?
-        .push(network);
+        .map_err(|_| NetworkError::FailedToWriteSupportedNetworks)?;
+
+    let strip = |fv: &str| fv.strip_prefix("0x").unwrap_or(fv).to_string();
+    let already_registered = networks
+        .iter()
+        .any(|n| strip(n.genesis_fork_version_hex) == strip(network.genesis_fork_version_hex));
+
+    if !already_registered {
+        networks.push(network);
+    }
+
     Ok(())
 }
 
@@ -388,6 +402,35 @@ mod tests {
             }
             .is_non_zero()
         );
+    }
+
+    #[test]
+    fn add_test_network_accepts_custom_fork_version_and_is_idempotent() {
+        // A custom testnet fork version (e.g. a local kurtosis testnet) is not
+        // in the predefined allowlist and is rejected before registration.
+        let custom = Network {
+            chain_id: 3151908,
+            name: "kurtosis-idempotent-test",
+            genesis_fork_version_hex: "0x20000038",
+            genesis_timestamp: 1700000000,
+            capella_hard_fork: "0x20000038",
+        };
+        let fork_version = hex::decode("20000038").unwrap();
+
+        assert!(fork_version_to_chain_id(&fork_version).is_err());
+
+        // Registering it makes the fork version resolvable.
+        add_test_network(custom.clone()).unwrap();
+        assert_eq!(
+            fork_version_to_chain_id(&fork_version).unwrap(),
+            custom.chain_id
+        );
+
+        // Registering the same fork version again is a no-op (no duplicates).
+        let before = supported_networks().unwrap().len();
+        add_test_network(custom.clone()).unwrap();
+        let after = supported_networks().unwrap().len();
+        assert_eq!(before, after, "duplicate registration must be a no-op");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes for running **pluto as a drop-in charon replacement against a custom local testnet** (kurtosis, chain-id `3151908`, genesis fork version `0x10000038`), surfaced while validating pluto as charon-compatible DV middleware.

Three of the five reported issues had a fix target present on `main`; the other two (`pluto run` rejecting `--testnet-*`, and the monitoring API) live in the not-yet-merged run engine and are **deferred** (see below).

## Changes

### 1. Dockerfile — charon-compatible working directory
The runtime (`distroless/cc-debian13`) stage set **no `WORKDIR`**, so pluto's CWD was `/`, whereas charon runs from `/opt/charon` (`charon/Dockerfile`). Relative paths passed to flags like `--split-keys-dir` / `--cluster-dir` resolved against the wrong directory and failed with a `walk directory error: ... No such file or directory`.

Setting `WORKDIR /opt/charon` matches charon and restores drop-in compatibility. The distroless base has no shell, so `WORKDIR` (a builder instruction) is used to create the directory rather than a `RUN mkdir`.

### 2. `create cluster` — accept custom fork versions when verifying a definition file
`create cluster --definition-file=<custom-testnet-def>` failed with `eip712 error: Network error: Invalid fork version: 10000038`. `load_definition` runs EIP-712 signature verification, which resolves the definition's fork version against the supported-networks allowlist — but the custom testnet was only registered **later**, in `validate_network_config`. Registration is now hoisted **before** `load_definition`, and a custom fork version no longer force-maps onto the built-in `Network` enum.

### 3. `network::add_test_network` — idempotent registration
Now keyed on genesis fork version, so the two registration sites (flag-driven config path and definition verification) can each register the same custom testnet without creating duplicate allowlist entries.

## Deferred (not on `main` yet)
The `pluto run` workflow is currently `unimplemented!()` on `main`; cluster-lock loading, `--testnet-*` acceptance in `run`, and the monitoring/Prometheus API all live in the in-progress run engine. Those parts of the original investigation (run rejecting `--testnet-*`; monitoring API unimplemented) will be addressed once the run engine lands. The QBFT "duty expired" startup logs were investigated and found to be a benign startup transient, not a bug.

## Testing
- `cargo test -p pluto-eth2util network::` — 7 passed (incl. new `add_test_network_accepts_custom_fork_version_and_is_idempotent`)
- `cargo test -p pluto-cli create_cluster` — 32 passed (incl. `custom_testnet_flags`, `solo_flow_definition_from_disk`)
- `cargo clippy -p pluto-eth2util -p pluto-cli --all-targets` — clean