### PR TITLE
fix(ci): add --locked to cargo install

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,13 +46,13 @@ jobs:
           version: 3.21.12
 
       - name: Install `oas3-gen`
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Install `llvm-tools-preview`
         run: rustup component add llvm-tools-preview
 
       - name: Install `cargo-llvm-cov`
-        run: cargo install cargo-llvm-cov@0.6.24
+        run: cargo install cargo-llvm-cov@0.6.24 --locked
 
       - name: Generate coverage report
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info --ignore-filename-regex '^examples/'

--- a/.github/workflows/create-cluster-compare.yml
+++ b/.github/workflows/create-cluster-compare.yml
@@ -68,7 +68,7 @@ jobs:
           version: 3.21.12
 
       - name: Install oas3-gen
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Build pluto
         run: cargo build -p pluto-cli

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,10 +28,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install `cargo-deny`
-        run: cargo install cargo-deny@0.19.0
+        run: cargo install cargo-deny@0.19.0 --locked
 
       - name: Install `cargo-machete`
-        run: cargo install cargo-machete@0.9.2
+        run: cargo install cargo-machete@0.9.2 --locked
 
       - name: Run `cargo-deny` audit
         run: cargo deny check

--- a/.github/workflows/dkg-runner.yml
+++ b/.github/workflows/dkg-runner.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install oas3-gen
         if: matrix.pluto_nodes > 0
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Build pluto
         if: matrix.pluto_nodes > 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
           version: 3.21.12
 
       - name: Install `oas3-gen`
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Setup pages
         id: pages

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -53,7 +53,7 @@ jobs:
           version: 3.21.12
 
       - name: Install `oas3-gen`
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Install `rustfmt`
         run: rustup +nightly component add rustfmt

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -44,7 +44,7 @@ jobs:
           version: 3.21.12
 
       - name: Install `oas3-gen`
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Get latest version tag
         id: get-baseline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
           version: 3.21.12
 
       - name: Install `oas3-gen`
-        run: cargo install oas3-gen@0.24.0
+        run: cargo install oas3-gen@0.24.0 --locked
 
       - name: Build (all features)
         run: cargo test --locked --workspace --all-features --no-run


### PR DESCRIPTION
## Changes 

Add `--locked` to every `cargo install` invocation across all CI workflows.

## Reason 

`cargo install <tool>@<ver>` without `--locked` re-resolves the tool's  dependency tree to the newest semver-compatible versions at install  time, ignoring the `Cargo.lock` its maintainers shipped and tested. For  `cargo-deny@0.19.0` this pulls in `kstring@2.0.3` (MSRV 1.96.0), which  fails to build on the toolchain pinned to `1.95.0` in  `rust-toolchain.toml` — breaking the `dependency-audit` workflow.

`--locked` forces cargo to use each tool's bundled lockfile — the  versions vetted against that tool's own MSRV — so no MSRV-exceeding  transitive upgrade sneaks in. Applying it to every `cargo install` (not  just the one that broke) hardens the rest against the same latent hazard  and is standard practice for reproducible CI.