### PR TITLE
fix(dkg): relax `started` atomic ordering from SeqCst to Relaxed

### DIFF
--- a/crates/consensus/src/qbft/runner.rs
+++ b/crates/consensus/src/qbft/runner.rs
@@ -412,6 +412,9 @@ async fn run_instance_inner(
 
     match core_result {
         Ok(()) => Ok(()),
+        // `Relaxed` suffices: the store runs inside the `spawn_blocking` task
+        // above, whose completion (awaited via the join handle) synchronizes-with
+        // this load, so the write is already visible here.
         Err(qbft::QbftError::ContextCanceled) if decided.load(Ordering::Relaxed) => Ok(()),
         Err(qbft::QbftError::ContextCanceled) => {
             metrics::inc_qbft_consensus_timeout(&duty, timer_type);

--- a/crates/dkg/src/sync/server.rs
+++ b/crates/dkg/src/sync/server.rs
@@ -56,7 +56,10 @@ impl Server {
 
     /// Starts the server side of the protocol.
     pub fn start(&self) {
-        self.inner.started.store(true, Ordering::SeqCst);
+        // `started` is a standalone signal flag; it publishes no data of its
+        // own (server state lives behind the `RwLock`, wake-ups come from
+        // `Notify`), so `Relaxed` is sufficient.
+        self.inner.started.store(true, Ordering::Relaxed);
         self.inner.notify.notify_waiters();
     }
 
@@ -71,7 +74,7 @@ impl Server {
             let notified = self.inner.notify.notified();
             tokio::pin!(notified);
 
-            if !self.inner.started.load(Ordering::SeqCst) {
+            if !self.inner.started.load(Ordering::Relaxed) {
                 tokio::select! {
                     _ = cancellation.cancelled() => return Err(Error::Canceled),
                     _ = &mut notified => {}
@@ -176,7 +179,7 @@ impl Server {
     }
 
     pub(crate) fn is_started(&self) -> bool {
-        self.inner.started.load(Ordering::SeqCst)
+        self.inner.started.load(Ordering::Relaxed)
     }
 
     pub(crate) async fn set_connected(&self, peer_id: PeerId) -> (bool, usize) {


### PR DESCRIPTION
## Summary

Audited all production atomic-ordering usage in the workspace. The vast majority of sites already use the optimal ordering; this PR addresses the single inefficiency found.

**`crates/dkg/src/sync/server.rs`** — the `started` `AtomicBool` used `SeqCst` for its store/load (3 sites). The flag is a standalone signal: it publishes no data of its own (server state lives behind the `RwLock`, wake-ups come from `Notify`), and it is the only atomic in play. A global total order (`SeqCst`) is therefore unnecessary — it just adds fences (`dmb ish` + `ldar`/`stlr` on AArch64; `xchg`/`mfence` vs. plain `mov` on x86). Downgraded to `Relaxed`, which is sufficient for the register-then-check `Notify` idiom (correctness comes from registering `notified()` before the load, not from the atomic's ordering).

Also added an explanatory comment on the QBFT runner's `decided` flag documenting why its existing `Relaxed` load is already correct (visibility is guaranteed by the `spawn_blocking` join, not the atomic ordering).

## Audit result (production sites)

| Location | Atomic | Ordering | Verdict |
|----------|--------|----------|---------|
| `consensus/instance.rs` | 3× flags | `Relaxed` | already optimal (claim tokens; resources behind `Mutex`) |
| `consensus/qbft/p2p.rs`, `parsigex/behaviour.rs` | request-id counters | `Relaxed` | already optimal (uniqueness only) |
| `consensus/qbft/runner.rs` | `decided` | `Relaxed` | correct (join provides happens-before) — comment added |
| `dkg/sync/server.rs` | `started` | `SeqCst` → **`Relaxed`** | **this PR** |

No correctness bugs were found — no `Relaxed` site was dangerously under-strengthened.

## Testing

- `cargo build -p pluto-dkg -p pluto-consensus`
- `cargo clippy -p pluto-dkg -p pluto-consensus --all-targets --all-features -- -D warnings`