### PR TITLE
fix(p2p): recover relay boot races so cluster peers stay routed

### DIFF
--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -41,7 +41,7 @@ pluto-cluster.workspace = true
 hex.workspace = true
 libp2p.workspace = true
 k256.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 futures.workspace = true
 
 [lints]

--- a/crates/p2p/src/relay/manager.rs
+++ b/crates/p2p/src/relay/manager.rs
@@ -1,7 +1,7 @@
 //! The [`RelayManager`] behaviour: reservation lifecycle and peer routing.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
     pin::Pin,
     task::{Context, Poll},
@@ -84,6 +84,18 @@ pub struct RelayManager {
     /// waiting for another `MutablePeer` update.
     relay_addrs: HashMap<PeerId, Vec<Multiaddr>>,
 
+    /// Circuit listen addresses the swarm has confirmed per relay.
+    ///
+    /// Each relay gets one `ListenOn` per transport address, and every
+    /// circuit listener confirms (`NewListenAddr`) or dies
+    /// (`ExpiredListenAddr`) independently — commonly a mix of both from the
+    /// same relay within milliseconds at boot, since concurrent listeners
+    /// race to reserve. A relay therefore only leaves `Reserved` when its
+    /// *last* confirmed address expires; reacting to any single expiry would
+    /// tear down peer routing while a sibling listener still holds a live
+    /// reservation.
+    reserved_addrs: HashMap<PeerId, HashSet<Multiaddr>>,
+
     /// Tracks when each relay last entered `Established` without having since
     /// reached `Reserved`. The watchdog uses this to identify relays whose
     /// reservation never confirmed (or whose refresh was denied so libp2p's
@@ -117,6 +129,7 @@ impl RelayManager {
             dial_states: HashMap::new(),
             connection_states: HashMap::new(),
             relay_addrs: HashMap::new(),
+            reserved_addrs: HashMap::new(),
             established_at: HashMap::new(),
             watchdog: None,
             p2p_context,
@@ -221,7 +234,8 @@ impl RelayManager {
         }
     }
 
-    /// Watchdog for relays stuck in `Established`.
+    /// Periodic recovery watchdog: relays stuck in `Established` and cluster
+    /// peers left with no connection and no dial campaign.
     ///
     /// Libp2p's relay client owns reservation refresh; if a relay denies a
     /// refresh (overloaded, quota exhausted, version mismatch), the client
@@ -233,7 +247,8 @@ impl RelayManager {
     /// [`ESTABLISHED_STUCK_THRESHOLD`] gets a `ToSwarm::CloseConnection`; the
     /// resulting `FromSwarm::ConnectionClosed` drives `on_connection_closed`
     /// → `redial_relay`, mirroring Charon's "no relay connection,
-    /// reconnecting" recovery path (`charon/p2p/relay.go:73-92`).
+    /// reconnecting" recovery path (`charon/p2p/relay.go:73-92`). The tick
+    /// then runs [`Self::sweep_disconnected_peers`].
     fn process_established_watchdog(&mut self, cx: &mut Context<'_>) {
         let watchdog = self.watchdog.get_or_insert_with(|| {
             let deadline = Instant::now()
@@ -275,6 +290,8 @@ impl RelayManager {
             });
         }
 
+        self.sweep_disconnected_peers();
+
         let next_deadline = now
             .checked_add(ESTABLISHED_WATCHDOG_TICK)
             .unwrap_or_else(Instant::now);
@@ -282,6 +299,43 @@ impl RelayManager {
         // initialised or polled it above.
         if let Some(watchdog) = self.watchdog.as_mut() {
             watchdog.as_mut().reset(next_deadline);
+        }
+    }
+
+    /// Re-arms circuit dial campaigns for known cluster peers that have
+    /// neither an active connection nor an in-flight campaign.
+    ///
+    /// Campaign teardown is edge-triggered (`ConnectionEstablished` or a
+    /// `DialPeerConditionFalse` rejection), so a lost race can strand a peer:
+    /// a campaign torn down for a connection that never actually establishes
+    /// gets no `ConnectionClosed` to re-arm it, and force-direct skips
+    /// zero-connection peers. Charon is immune by construction — it re-adds
+    /// relay addrs to the peerstore on a ticker and every send dials — so
+    /// this periodic sweep is the campaign-model equivalent of that loop.
+    fn sweep_disconnected_peers(&mut self) {
+        let local = self.p2p_context.local_peer_id();
+        let targets: Vec<PeerId> = {
+            let store = self.p2p_context.peer_store_lock();
+            self.p2p_context
+                .known_peers()
+                .iter()
+                .copied()
+                .filter(|id| Some(*id) != local)
+                .filter(|id| !self.dial_states.contains_key(id))
+                .filter(|id| !store.has_connection(id))
+                .collect()
+        };
+
+        for target in targets {
+            self.upsert_peer_dial(target);
+            // upsert is a no-op while no relay is reserved (no circuit addrs);
+            // only report actual re-arms.
+            if self.dial_states.contains_key(&target) {
+                tracing::info!(
+                    peer_id = %target,
+                    "Cluster peer had no connection and no dial campaign; re-armed circuit dial"
+                );
+            }
         }
     }
 
@@ -397,7 +451,21 @@ impl RelayManager {
                     )));
                 self.set_relay_state(peer_id, RelayConnectionState::Established);
 
-                for circuit_addr in Self::circuit_addrs(peer_id, &dial_state.addrs) {
+                // Request exactly ONE circuit listener per relay. libp2p's
+                // relay client holds a single reservation per relay
+                // connection and routes `ListenOn` to the existing connection
+                // by peer id, so every additional listener displaces the
+                // previous listener's reservation: N listeners race each
+                // other at boot (confirm/expire churn) and can settle with no
+                // live reservation at all. One listener reserves once,
+                // cleanly. Dialers don't depend on which transport address is
+                // embedded in our advertised circuit address — both pluto and
+                // charon construct a target's circuit addresses from the
+                // relay's own transport addresses.
+                if let Some(circuit_addr) = Self::circuit_addrs(peer_id, &dial_state.addrs)
+                    .into_iter()
+                    .next()
+                {
                     tracing::debug!(
                         relay_peer_id = %peer_id,
                         %circuit_addr,
@@ -421,8 +489,9 @@ impl RelayManager {
     }
 
     /// Reacts to a new listen address. If it's a circuit address for one of
-    /// our relays, promotes that relay's state to `Reserved` and re-routes
-    /// known peers through the updated set of reserved relays.
+    /// our relays, records it as confirmed and promotes that relay's state to
+    /// `Reserved`, re-routing known peers through the updated set of reserved
+    /// relays.
     fn on_new_listen_addr(&mut self, addr: &Multiaddr) {
         let Some(relay_id) = Self::relay_id_from_circuit_addr(addr) else {
             return;
@@ -439,7 +508,12 @@ impl RelayManager {
                 );
             }
             RelayConnectionState::Reserved => {
-                // Second circuit address from the same relay — already routed.
+                // Additional circuit address from the same relay — already
+                // routed, just record it.
+                self.reserved_addrs
+                    .entry(relay_id)
+                    .or_default()
+                    .insert(addr.clone());
             }
             RelayConnectionState::Established => {
                 tracing::info!(
@@ -447,6 +521,10 @@ impl RelayManager {
                     listen_addr = %addr,
                     "Relay reservation confirmed; routing known peers via this relay"
                 );
+                self.reserved_addrs
+                    .entry(relay_id)
+                    .or_default()
+                    .insert(addr.clone());
                 self.set_relay_state(relay_id, RelayConnectionState::Reserved);
                 self.events
                     .push_back(ToSwarm::GenerateEvent(RelayManagerEvent::RelayReserved(
@@ -457,11 +535,16 @@ impl RelayManager {
         }
     }
 
-    /// Reacts to a circuit listen address expiring. If the relay was in
-    /// `Reserved`, demote it to `Established` so we stop routing peers through
-    /// it. libp2p's circuit-client will normally refresh the reservation and
-    /// emit `NewListenAddr` again, which promotes us back. If the transport
-    /// connection also drops, `on_connection_closed` will handle the redial.
+    /// Reacts to a circuit listen address expiring. The relay is demoted to
+    /// `Established` (stop routing peers through it) only when its *last*
+    /// confirmed circuit address expires: expiries of never-confirmed or
+    /// sibling listeners are routine — the swarm runs one circuit listener
+    /// per relay transport address and they race to reserve, so a losing
+    /// listener's expiry regularly arrives moments after a winning one's
+    /// confirmation. After a genuine demote, libp2p's circuit-client will
+    /// normally refresh the reservation and emit `NewListenAddr` again, which
+    /// promotes us back. If the transport connection also drops,
+    /// `on_connection_closed` will handle the redial.
     fn on_expired_listen_addr(&mut self, addr: &Multiaddr) {
         let Some(relay_id) = Self::relay_id_from_circuit_addr(addr) else {
             return;
@@ -469,11 +552,28 @@ impl RelayManager {
         let Some(state) = self.connection_states.get(&relay_id).copied() else {
             return;
         };
+
+        let confirmed_remain = match self.reserved_addrs.get_mut(&relay_id) {
+            Some(confirmed) => {
+                confirmed.remove(addr);
+                !confirmed.is_empty()
+            }
+            None => false,
+        };
+
         if matches!(state, RelayConnectionState::Reserved) {
+            if confirmed_remain {
+                tracing::debug!(
+                    relay_peer_id = %relay_id,
+                    listen_addr = %addr,
+                    "Relay circuit listener expired; other confirmed circuits remain, staying Reserved"
+                );
+                return;
+            }
             tracing::info!(
                 relay_peer_id = %relay_id,
                 listen_addr = %addr,
-                "Relay circuit listener expired; demoting to Established"
+                "Last confirmed relay circuit listener expired; demoting to Established"
             );
             self.set_relay_state(relay_id, RelayConnectionState::Established);
             self.events.push_back(ToSwarm::GenerateEvent(
@@ -523,10 +623,18 @@ impl RelayManager {
     /// refused the dial because we're already connected to (or dialing) the
     /// target. Behaviour depends on the dial type:
     ///
-    /// - [`RelayDialType::ClusterPeer`]: libp2p owns the existing direct
-    ///   connection. Drop the dial state and rely on
+    /// - [`RelayDialType::ClusterPeer`] with an active connection: libp2p owns
+    ///   the existing connection. Drop the dial state and rely on
     ///   [`Self::on_connection_closed`] → [`Self::reroute_peer`] to re-arm the
     ///   dial once the existing connection actually closes.
+    /// - [`RelayDialType::ClusterPeer`] without an active connection: the
+    ///   condition failed because an earlier dial (typically this campaign's
+    ///   own previous attempt, still negotiating a relay circuit) is in flight.
+    ///   Keep the campaign armed: if that in-flight dial fails — e.g. the relay
+    ///   has no reservation for the target yet during the boot race — no
+    ///   `ConnectionClosed` ever fires for a connection that never established,
+    ///   so a dropped campaign would leave the peer permanently unrouted
+    ///   (force-direct skips zero-connection peers).
     /// - [`RelayDialType::RelayServer`]: dropping the dial state here would
     ///   wedge `connection_states` in `Dialing` forever — no
     ///   `on_connection_closed` will fire if libp2p already has the transport
@@ -547,14 +655,24 @@ impl RelayManager {
         if skipped {
             match target {
                 RelayDialType::ClusterPeer => {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        dial_type = ?target,
-                        retry_count,
-                        %error,
-                        "Dial skipped (already connected or dialing); dropping dial state"
-                    );
-                    self.dial_states.remove(&peer_id);
+                    if self.p2p_context.peer_store_lock().has_connection(&peer_id) {
+                        tracing::debug!(
+                            peer_id = %peer_id,
+                            dial_type = ?target,
+                            retry_count,
+                            %error,
+                            "Dial skipped (already connected); dropping dial state"
+                        );
+                        self.dial_states.remove(&peer_id);
+                    } else {
+                        tracing::debug!(
+                            peer_id = %peer_id,
+                            dial_type = ?target,
+                            retry_count,
+                            %error,
+                            "Dial skipped while a dial is still in flight; keeping campaign armed"
+                        );
+                    }
                 }
                 RelayDialType::RelayServer => {
                     tracing::debug!(
@@ -587,6 +705,9 @@ impl RelayManager {
 
     /// Schedules a re-dial for a relay whose last connection just dropped.
     fn redial_relay(&mut self, relay_id: PeerId) {
+        // The transport connection is gone, so every circuit listener through
+        // this relay is dead regardless of expiry events seen so far.
+        self.reserved_addrs.remove(&relay_id);
         let Some(addrs) = self.relay_addrs.get(&relay_id).cloned() else {
             tracing::warn!(
                 relay_peer_id = %relay_id,
@@ -690,8 +811,12 @@ impl NetworkBehaviour for RelayManager {
             self.queue_relay_update(peer);
         }
 
-        self.process_relay_dials(cx);
+        // Watchdog first: its sweep can insert immediately-ready dial states,
+        // and `process_relay_dials` must poll them in this same pass so their
+        // dials fire (and their sleeps register wakers) without waiting for
+        // the next tick.
         self.process_established_watchdog(cx);
+        self.process_relay_dials(cx);
 
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event);

--- a/crates/p2p/src/relay/manager/tests.rs
+++ b/crates/p2p/src/relay/manager/tests.rs
@@ -292,7 +292,10 @@ async fn queue_relay_update_no_op_when_relay_already_connected() {
 async fn on_connection_established_relay_promotes_to_established_and_queues_listen() {
     let mut mgr = manager();
     let relay_id = PeerId::random();
-    let relay_addrs = vec![addr("/ip4/10.0.0.1/tcp/9000")];
+    let relay_addrs = vec![
+        addr("/ip4/10.0.0.1/tcp/9000"),
+        addr("/ip4/10.0.0.1/udp/9000/quic-v1"),
+    ];
 
     mgr.queue_relay_update(relay_peer(relay_id, relay_addrs.clone()));
     mgr.events.clear();
@@ -308,7 +311,10 @@ async fn on_connection_established_relay_promotes_to_established_and_queues_list
         .iter()
         .filter(|e| matches!(e, ToSwarm::ListenOn { .. }))
         .count();
-    assert_eq!(listen_count, relay_addrs.len());
+    // Exactly one circuit listener regardless of how many transport addrs the
+    // relay has: libp2p keeps a single reservation per relay connection, so
+    // additional listeners would displace each other.
+    assert_eq!(listen_count, 1);
     let relay_connected = mgr.events.iter().any(|e| {
         matches!(
             e,
@@ -377,17 +383,23 @@ async fn on_new_listen_addr_promotes_established_to_reserved() {
 // ---- state machine: on_expired_listen_addr -------------------------
 
 #[tokio::test]
-async fn on_expired_listen_addr_demotes_reserved_and_emits_reservation_lost() {
+async fn on_expired_listen_addr_demotes_when_last_confirmed_circuit_expires() {
     let mut mgr = manager();
     let relay_id = PeerId::random();
     mgr.connection_states
-        .insert(relay_id, RelayConnectionState::Reserved);
+        .insert(relay_id, RelayConnectionState::Established);
     mgr.relay_addrs
         .insert(relay_id, vec![addr("/ip4/10.0.0.1/tcp/9000")]);
 
     let circuit = addr(&format!(
         "/ip4/10.0.0.1/tcp/9000/p2p/{relay_id}/p2p-circuit"
     ));
+    mgr.on_new_listen_addr(&circuit);
+    assert_eq!(
+        mgr.connection_states.get(&relay_id),
+        Some(&RelayConnectionState::Reserved)
+    );
+
     mgr.on_expired_listen_addr(&circuit);
 
     assert_eq!(
@@ -405,6 +417,59 @@ async fn on_expired_listen_addr_demotes_reserved_and_emits_reservation_lost() {
 }
 
 #[tokio::test]
+async fn on_expired_listen_addr_ignores_unconfirmed_sibling_listener_expiry() {
+    // Regression for the boot race: one circuit listener confirms
+    // (NewListenAddr) and a sibling listener that never confirmed expires
+    // moments later. The relay must stay Reserved and keep routing peers —
+    // demoting here partitioned the node for a full watchdog cycle.
+    let mut mgr = manager();
+    let relay_id = PeerId::random();
+    let target = PeerId::random();
+    mgr.connection_states
+        .insert(relay_id, RelayConnectionState::Established);
+    mgr.relay_addrs.insert(
+        relay_id,
+        vec![
+            addr("/ip4/10.0.0.1/tcp/9000"),
+            addr("/ip4/10.0.0.1/udp/9000/quic-v1"),
+        ],
+    );
+
+    let confirmed = addr(&format!(
+        "/ip4/10.0.0.1/tcp/9000/p2p/{relay_id}/p2p-circuit"
+    ));
+    let unconfirmed = addr(&format!(
+        "/ip4/10.0.0.1/udp/9000/quic-v1/p2p/{relay_id}/p2p-circuit"
+    ));
+    mgr.on_new_listen_addr(&confirmed);
+    // A peer routing campaign armed through the reserved relay.
+    mgr.upsert_peer_dial(target);
+    assert!(mgr.dial_states.contains_key(&target));
+
+    mgr.on_expired_listen_addr(&unconfirmed);
+
+    assert_eq!(
+        mgr.connection_states.get(&relay_id),
+        Some(&RelayConnectionState::Reserved),
+        "expiry of a never-confirmed listener must not demote the relay"
+    );
+    assert!(
+        mgr.dial_states.contains_key(&target),
+        "peer routing campaigns must survive the sibling-listener expiry"
+    );
+    let lost = mgr.events.iter().any(|e| {
+        matches!(
+            e,
+            ToSwarm::GenerateEvent(RelayManagerEvent::RelayReservationLost(_))
+        )
+    });
+    assert!(
+        !lost,
+        "no ReservationLost while a confirmed circuit remains"
+    );
+}
+
+#[tokio::test]
 async fn on_expired_listen_addr_drops_peer_dials_with_no_route_left() {
     let mut mgr = manager();
     let relay_id = PeerId::random();
@@ -412,9 +477,13 @@ async fn on_expired_listen_addr_drops_peer_dials_with_no_route_left() {
 
     // Single reserved relay supporting a peer-routing dial.
     mgr.connection_states
-        .insert(relay_id, RelayConnectionState::Reserved);
+        .insert(relay_id, RelayConnectionState::Established);
     mgr.relay_addrs
         .insert(relay_id, vec![addr("/ip4/10.0.0.1/tcp/9000")]);
+    let circuit = addr(&format!(
+        "/ip4/10.0.0.1/tcp/9000/p2p/{relay_id}/p2p-circuit"
+    ));
+    mgr.on_new_listen_addr(&circuit);
     mgr.dial_states.insert(
         target,
         RelayDialState::new(
@@ -426,14 +495,37 @@ async fn on_expired_listen_addr_drops_peer_dials_with_no_route_left() {
         ),
     );
 
-    let circuit = addr(&format!(
-        "/ip4/10.0.0.1/tcp/9000/p2p/{relay_id}/p2p-circuit"
-    ));
     mgr.on_expired_listen_addr(&circuit);
 
     assert!(
         !mgr.dial_states.contains_key(&target),
         "peer dial state must be dropped once no reserved relay can route to it"
+    );
+}
+
+#[tokio::test]
+async fn redial_relay_clears_confirmed_circuits() {
+    // The transport connection dropping kills every circuit listener; stale
+    // confirmed addrs must not keep a future Reserved state alive across
+    // reconnects.
+    let mut mgr = manager();
+    let relay_id = PeerId::random();
+    mgr.connection_states
+        .insert(relay_id, RelayConnectionState::Established);
+    mgr.relay_addrs
+        .insert(relay_id, vec![addr("/ip4/10.0.0.1/tcp/9000")]);
+    let circuit = addr(&format!(
+        "/ip4/10.0.0.1/tcp/9000/p2p/{relay_id}/p2p-circuit"
+    ));
+    mgr.on_new_listen_addr(&circuit);
+
+    mgr.on_connection_closed(relay_id);
+
+    assert!(
+        mgr.reserved_addrs
+            .get(&relay_id)
+            .is_none_or(HashSet::is_empty),
+        "confirmed circuit addrs must be cleared on relay disconnect"
     );
 }
 
@@ -505,8 +597,47 @@ fn skipped_dial_error() -> DialError {
     )
 }
 
+/// Records an active connection to `peer` in the manager's peer store, as
+/// `conn_logger` would on `ConnectionEstablished`.
+fn record_connection(mgr: &RelayManager, peer: PeerId) {
+    mgr.p2p_context
+        .peer_store_write_lock()
+        .add_peer(crate::p2p_context::Peer {
+            id: peer,
+            connection_id: libp2p::swarm::ConnectionId::new_unchecked(1),
+            remote_addr: addr("/ip4/10.0.0.9/tcp/9000"),
+        });
+}
+
 #[tokio::test]
-async fn on_dial_failure_skipped_cluster_peer_drops_dial_state() {
+async fn on_dial_failure_skipped_connected_cluster_peer_drops_dial_state() {
+    let mut mgr = manager();
+    let target = PeerId::random();
+    record_connection(&mgr, target);
+    mgr.dial_states.insert(
+        target,
+        RelayDialState::new(
+            RelayDialType::ClusterPeer,
+            target,
+            vec![addr("/ip4/10.0.0.1/tcp/9000")],
+        ),
+    );
+
+    mgr.on_dial_failure(Some(target), &skipped_dial_error());
+
+    assert!(
+        !mgr.dial_states.contains_key(&target),
+        "cluster-peer dial state must be dropped on Skipped while connected"
+    );
+}
+
+#[tokio::test]
+async fn on_dial_failure_skipped_disconnected_cluster_peer_keeps_campaign() {
+    // Regression for the boot-race wedge: dial #2 of a campaign is rejected
+    // with DialPeerConditionFalse because dial #1 is still negotiating its
+    // relay circuit. Dropping the campaign here orphans the peer if dial #1
+    // then fails (a never-established connection produces no
+    // ConnectionClosed, and force-direct skips zero-connection peers).
     let mut mgr = manager();
     let target = PeerId::random();
     mgr.dial_states.insert(
@@ -521,8 +652,8 @@ async fn on_dial_failure_skipped_cluster_peer_drops_dial_state() {
     mgr.on_dial_failure(Some(target), &skipped_dial_error());
 
     assert!(
-        !mgr.dial_states.contains_key(&target),
-        "cluster-peer dial state must be dropped on Skipped"
+        mgr.dial_states.contains_key(&target),
+        "campaign must stay armed while the peer has no active connection"
     );
 }
 
@@ -635,5 +766,112 @@ async fn upsert_peer_dial_drops_stale_state_when_no_route_left() {
     assert!(
         !mgr.dial_states.contains_key(&target),
         "no reserved relay can reach target: stale dial state must be dropped"
+    );
+}
+
+// ---- sweep_disconnected_peers --------------------------------------
+
+/// Manager with one reserved relay and the given known cluster peers.
+fn manager_with_reserved_relay(known: Vec<PeerId>) -> RelayManager {
+    let mut mgr = RelayManager::new(Vec::new(), P2PContext::new(known));
+    let relay = PeerId::random();
+    mgr.connection_states
+        .insert(relay, RelayConnectionState::Reserved);
+    mgr.relay_addrs
+        .insert(relay, vec![addr("/ip4/10.0.0.1/tcp/9000")]);
+    mgr
+}
+
+#[tokio::test]
+async fn sweep_rearms_known_peer_with_no_connection_and_no_campaign() {
+    // Regression for the boot-race wedge's terminal state: a known peer with
+    // zero connections and no dial campaign must be picked up by the sweep.
+    let target = PeerId::random();
+    let mut mgr = manager_with_reserved_relay(vec![target]);
+
+    mgr.sweep_disconnected_peers();
+
+    assert!(
+        mgr.dial_states.contains_key(&target),
+        "sweep must re-arm a circuit dial for the unrouted peer"
+    );
+}
+
+#[tokio::test]
+async fn sweep_skips_connected_peers_and_in_flight_campaigns_and_self() {
+    let connected = PeerId::random();
+    let campaigning = PeerId::random();
+    let local = PeerId::random();
+    let mut mgr = manager_with_reserved_relay(vec![connected, campaigning, local]);
+    mgr.p2p_context.set_local_peer_id(local);
+    record_connection(&mgr, connected);
+    mgr.dial_states.insert(
+        campaigning,
+        RelayDialState::new(
+            RelayDialType::ClusterPeer,
+            campaigning,
+            vec![addr("/ip4/10.0.0.1/tcp/9000")],
+        ),
+    );
+    let campaign_retry_count = 3;
+    if let Some(s) = mgr.dial_states.get_mut(&campaigning) {
+        s.retry_count = campaign_retry_count;
+    }
+
+    mgr.sweep_disconnected_peers();
+
+    assert!(
+        !mgr.dial_states.contains_key(&connected),
+        "connected peer must not get a dial campaign"
+    );
+    assert!(
+        !mgr.dial_states.contains_key(&local),
+        "self must never be dialed"
+    );
+    assert_eq!(
+        mgr.dial_states.get(&campaigning).map(|s| s.retry_count),
+        Some(campaign_retry_count),
+        "existing campaign (and its backoff) must be left untouched"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn poll_fires_swept_peer_dial_within_the_same_watchdog_pass() {
+    // The sweep runs on the watchdog tick inside poll(); the dial state it
+    // inserts must be polled in the same pass. If it isn't, no waker is
+    // registered for it and — with nothing else waking the swarm — the dial
+    // waits a full extra watchdog tick.
+    let target = PeerId::random();
+    let mut mgr = manager_with_reserved_relay(vec![target]);
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    // Drain until Pending: initialises the watchdog.
+    while mgr.poll(&mut cx).is_ready() {}
+
+    tokio::time::advance(ESTABLISHED_WATCHDOG_TICK).await;
+
+    let mut saw_dial = false;
+    while let Poll::Ready(ev) = mgr.poll(&mut cx) {
+        if matches!(ev, ToSwarm::Dial { .. }) {
+            saw_dial = true;
+        }
+    }
+    assert!(
+        saw_dial,
+        "the swept peer's dial must fire in the same watchdog pass"
+    );
+}
+
+#[tokio::test]
+async fn sweep_is_noop_without_reserved_relays() {
+    let target = PeerId::random();
+    let mut mgr = RelayManager::new(Vec::new(), P2PContext::new(vec![target]));
+
+    mgr.sweep_disconnected_peers();
+
+    assert!(
+        !mgr.dial_states.contains_key(&target),
+        "no reserved relay: nothing to arm"
     );
 }


### PR DESCRIPTION
 ## Issue

  Pluto's relay manager (`crates/p2p/src/relay/manager.rs`) mishandles the circuit-reservation lifecycle at boot. Three bugs:

  1. **N listeners, 1 reservation.** One `ListenOn` was issued per relay transport address. libp2p's relay client holds a single reservation per relay connection and routes `ListenOn` by peer id, so each listener displaces the previous one — they race, sometimes settling with no live reservation. (`libp2p-relay-0.21.1/src/priv_client.rs`, `reservation_addresses`.)
  2. **Demote on any expiry.** `on_expired_listen_addr` demoted `Reserved → Established` on any circuit-addr expiry, including a never-confirmed sibling listener's, while another listener still held a live reservation.
  3. **Campaign dropped mid-flight.** `on_dial_failure` dropped a cluster-peer dial campaign on `DialPeerConditionFalse` assuming an existing connection — but that also fires while the campaign's own earlier dial is still negotiating. If that dial then failed, no `ConnectionClosed` ever fired (nothing established) and force-direct skips zero-connection peers, so the peer was never dialed again.

  ## Impact

  A node could sit partitioned for up to 60s after boot — demoted from `Reserved`, all peer routing dropped, cross-impl peers getting `NO_RESERVATION`. In the compose smoke test this surfaced as an intermittent alert-gate failure (~1/N runs) with no ERROR log. Pre-existing in `main`; unrelated to any single caller.

  ## Solution

  - Request exactly one circuit listener per relay (dialers build a target's circuit addrs from the relay's transport addrs regardless of which we advertise — same as Charon).
  - Track confirmed circuit addrs per relay (`reserved_addrs`); demote only when the last one expires.
  - On `DialPeerConditionFalse`, drop the campaign only if the peer store shows an active connection; otherwise keep it armed.
  - Add a zero-connection sweeper on the existing 15s watchdog tick to re-arm any known peer left with no connection and no campaign — the campaign-model equivalent of Charon's `NewRelayRouter` re-publish loop. Watchdog now runs before `process_relay_dials` in `poll` so a swept dial fires the same pass.