### PR TITLE
test(app): fix flaky validator cache wiring test

### DIFF
--- a/crates/app/tests/wiring.rs
+++ b/crates/app/tests/wiring.rs
@@ -53,7 +53,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use wiremock::{
     Mock, MockServer, Request, ResponseTemplate,
-    matchers::{method, path},
+    matchers::{method, path, path_regex},
 };
 
 const PK_LEN: usize = 48;
@@ -130,16 +130,16 @@ fn validator_datum(index: u64, pubkey: PubKey) -> GetStateValidatorsResponseResp
     }
 }
 
-/// Mounts POST `/eth/v1/beacon/states/head/validators` (the endpoint
-/// `ValidatorCache::get_by_head` queries) returning ONLY the datums whose
-/// pubkey appears in the request-body `ids` — so an unseeded (empty-pubkey)
-/// cache resolves zero validators.
+/// Mounts POST `/eth/v1/beacon/states/{state_id}/validators` returning ONLY the
+/// datums whose pubkey appears in the request-body `ids` — so an unseeded
+/// (empty-pubkey) cache resolves zero validators. Cover both `head` and slot
+/// state IDs because the scheduler refreshes the cache by slot immediately.
 async fn mount_filtered_post_validators(
     server: &MockServer,
     datums: Vec<GetStateValidatorsResponseResponseDatum>,
 ) {
     Mock::given(method("POST"))
-        .and(path("/eth/v1/beacon/states/head/validators"))
+        .and(path_regex(r"^/eth/v1/beacon/states/[^/]+/validators$"))
         .respond_with(move |request: &Request| {
             let body = String::from_utf8_lossy(&request.body);
             let data: Vec<_> = datums


### PR DESCRIPTION
## Problem

  `wiring_seeds_shared_validator_cache` was flaky because its mock served validator data only for the `head` state.

  The scheduler immediately refreshes the shared cache using a numeric slot. BeaconMock returned an empty validator set for that request, which could overwrite the seeded cache before the assertion ran.

  ## Fix

  Serve filtered validator data for all state IDs, covering both `head` and slot requests.