### PR TITLE
fix(eth2api): filter proposer duties to the cluster's validators

### DIFF
--- a/crates/core/src/scheduler.rs
+++ b/crates/core/src/scheduler.rs
@@ -959,27 +959,24 @@ async fn fetch_proposer_duties(
     client: &pluto_eth2api::BeaconNodeClient,
 ) -> Result<Vec<types::ProposerDutyDefinition>> {
     let validators = validators.as_ref();
-    let req = pluto_eth2api::GetProposerDutiesRequest::builder()
-        .epoch(slot.epoch().to_string())
-        .build()
-        .map_err(pluto_eth2api::EthBeaconNodeApiClientError::RequestError)?;
-    let resp = client
+    // The endpoint covers every slot in the epoch, so the client narrows the
+    // response to our validators before the loop below sees it.
+    let indices = validators
+        .iter()
+        .map(|v| v.v_idx)
+        .collect::<std::collections::HashSet<_>>();
+    let duties: Vec<pluto_eth2api::GetProposerDutiesResponseResponseDatum> = client
         .api()
-        .get_proposer_duties(req)
-        .await
-        .map_err(pluto_eth2api::EthBeaconNodeApiClientError::RequestError)?;
+        .fetch_proposer_duties(slot.epoch(), slot.slots_per_epoch, &indices)
+        .await?;
 
-    let pro_duties: Vec<types::ProposerDutyDefinition> = match resp {
-        pluto_eth2api::GetProposerDutiesResponse::Ok(duties) => duties
-            .data
-            .into_iter()
-            .map(|d| {
-                d.try_into()
-                    .map_err(|_| pluto_eth2api::EthBeaconNodeApiClientError::UnexpectedResponse)
-            })
-            .collect::<std::result::Result<Vec<_>, _>>(),
-        _ => Err(pluto_eth2api::EthBeaconNodeApiClientError::UnexpectedResponse),
-    }?;
+    let pro_duties: Vec<types::ProposerDutyDefinition> = duties
+        .into_iter()
+        .map(|d| {
+            d.try_into()
+                .map_err(|_| pluto_eth2api::EthBeaconNodeApiClientError::UnexpectedResponse)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut result = vec![];
     for pro_duty in pro_duties.into_iter() {
@@ -993,6 +990,7 @@ async fn fetch_proposer_duties(
             .find(|v| v.v_idx == pro_duty.v_idx)
             .map(|v| v.pubkey)
         else {
+            // Unreachable unless the client's filter let something through.
             tracing::warn!(
                 vidx = pro_duty.v_idx,
                 slot = %slot.slot,

--- a/crates/core/src/scheduler.rs
+++ b/crates/core/src/scheduler.rs
@@ -965,18 +965,13 @@ async fn fetch_proposer_duties(
         .iter()
         .map(|v| v.v_idx)
         .collect::<std::collections::HashSet<_>>();
-    let duties: Vec<pluto_eth2api::GetProposerDutiesResponseResponseDatum> = client
+    let pro_duties: Vec<types::ProposerDutyDefinition> = client
         .api()
         .fetch_proposer_duties(slot.epoch(), slot.slots_per_epoch, &indices)
-        .await?;
-
-    let pro_duties: Vec<types::ProposerDutyDefinition> = duties
+        .await?
         .into_iter()
-        .map(|d| {
-            d.try_into()
-                .map_err(|_| pluto_eth2api::EthBeaconNodeApiClientError::UnexpectedResponse)
-        })
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+        .map(types::ProposerDutyDefinition::from)
+        .collect();
 
     let mut result = vec![];
     for pro_duty in pro_duties.into_iter() {

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -557,29 +557,13 @@ pub struct ProposerDutyDefinition {
     pub slot: SlotNumber,
 }
 
-impl TryFrom<pluto_eth2api::types::GetProposerDutiesResponseResponseDatum>
-    for ProposerDutyDefinition
-{
-    type Error = pluto_eth2api::EthBeaconNodeApiClientError;
-
-    fn try_from(
-        value: pluto_eth2api::types::GetProposerDutiesResponseResponseDatum,
-    ) -> Result<ProposerDutyDefinition, Self::Error> {
-        let pubkey = PubKey::try_from(value.pubkey.as_str())
-            .map_err(|_| pluto_eth2api::EthBeaconNodeApiClientError::ParseError("pubkey".into()))?;
-        let v_idx = value.validator_index.parse::<u64>().map_err(|_| {
-            pluto_eth2api::EthBeaconNodeApiClientError::ParseError("validator_index".into())
-        })?;
-        let slot =
-            SlotNumber::from(value.slot.parse::<u64>().map_err(|_| {
-                pluto_eth2api::EthBeaconNodeApiClientError::ParseError("slot".into())
-            })?);
-
-        Ok(ProposerDutyDefinition {
-            pubkey,
-            v_idx,
-            slot,
-        })
+impl From<pluto_eth2api::ProposerDuty> for ProposerDutyDefinition {
+    fn from(value: pluto_eth2api::ProposerDuty) -> ProposerDutyDefinition {
+        ProposerDutyDefinition {
+            pubkey: PubKey::from(value.pubkey),
+            v_idx: value.validator_index,
+            slot: SlotNumber::from(value.slot),
+        }
     }
 }
 

--- a/crates/eth2api/src/extensions.rs
+++ b/crates/eth2api/src/extensions.rs
@@ -1,12 +1,17 @@
 use crate::{
     BeaconStateFork, ConsensusVersion, EthBeaconNodeApiClient, EventstreamRequestQueryTopic,
     GetForkScheduleRequest, GetForkScheduleResponse, GetGenesisRequest, GetGenesisResponse,
-    GetGenesisResponseResponseData, GetSpecRequest, GetSpecResponse, ValidatorStatus, spec::phase0,
+    GetGenesisResponseResponseData, GetProposerDutiesRequest, GetProposerDutiesResponse,
+    GetProposerDutiesResponseResponseDatum, GetSpecRequest, GetSpecResponse, ValidatorStatus,
+    spec::phase0,
 };
 use chrono::{DateTime, Utc};
 use eventsource_stream::Eventsource;
 use futures::{Stream, StreamExt};
-use std::{collections::HashMap, time};
+use std::{
+    collections::{HashMap, HashSet},
+    time,
+};
 use tree_hash::TreeHash;
 
 /// Error that can occur when using the
@@ -33,6 +38,15 @@ pub enum EthBeaconNodeApiClientError {
     /// Zero slot duration or slots per epoch in network spec
     #[error("Zero slot duration or slots per epoch in network spec")]
     ZeroSlotDurationOrSlotsPerEpoch,
+
+    /// A duty was returned for a slot outside the epoch it was requested for.
+    #[error("Received duty for slot {slot} outside of requested epoch {epoch}")]
+    DutySlotOutsideEpoch {
+        /// Slot the beacon node reported the duty for.
+        slot: phase0::Slot,
+        /// Epoch the duties were requested for.
+        epoch: phase0::Epoch,
+    },
 
     /// Domain type not found in the beacon spec response
     #[error("Domain type not found: {0}")]
@@ -339,6 +353,69 @@ impl EthBeaconNodeApiClient {
         }
 
         Ok((slot_duration, slots_per_epoch))
+    }
+
+    /// Fetches the proposer duties for `epoch`, keeping only the duties that
+    /// belong to `indices`. An empty `indices` returns them all.
+    ///
+    /// The endpoint takes no validator parameter — it always answers with the
+    /// proposer of every slot in the epoch — so narrowing it is the client's
+    /// job.
+    pub async fn fetch_proposer_duties(
+        &self,
+        epoch: phase0::Epoch,
+        slots_per_epoch: u64,
+        indices: &HashSet<phase0::ValidatorIndex>,
+    ) -> Result<Vec<GetProposerDutiesResponseResponseDatum>, EthBeaconNodeApiClientError> {
+        if slots_per_epoch == 0 {
+            return Err(EthBeaconNodeApiClientError::ZeroSlotDurationOrSlotsPerEpoch);
+        }
+
+        let request = GetProposerDutiesRequest::builder()
+            .epoch(epoch.to_string())
+            .build()
+            .map_err(EthBeaconNodeApiClientError::RequestError)?;
+
+        let duties = match self.get_proposer_duties(request).await? {
+            GetProposerDutiesResponse::Ok(response) => response.data,
+            _ => return Err(EthBeaconNodeApiClientError::UnexpectedResponse),
+        };
+
+        // Validate every duty before dropping any: filtering first would
+        // silently discard a malformed duty that happens to belong to a
+        // validator we did not ask about.
+        let mut validated = Vec::with_capacity(duties.len());
+        for duty in duties {
+            let index = duty
+                .validator_index
+                .parse::<phase0::ValidatorIndex>()
+                .map_err(|_| {
+                    EthBeaconNodeApiClientError::ParseError("proposer duty validator_index".into())
+                })?;
+            let slot = duty.slot.parse::<phase0::Slot>().map_err(|_| {
+                EthBeaconNodeApiClientError::ParseError("proposer duty slot".into())
+            })?;
+            let _: phase0::BLSPubKey =
+                decode_fixed_hex(&duty.pubkey, || "decode proposer duty pubkey".to_string())?;
+
+            // Reject duties outside the requested epoch. Comparing epochs
+            // avoids the slot-bound multiplication overflowing on a bogus
+            // epoch.
+            let duty_epoch = slot
+                .checked_div(slots_per_epoch)
+                .ok_or(EthBeaconNodeApiClientError::ZeroSlotDurationOrSlotsPerEpoch)?;
+            if duty_epoch != epoch {
+                return Err(EthBeaconNodeApiClientError::DutySlotOutsideEpoch { slot, epoch });
+            }
+
+            validated.push((index, duty));
+        }
+
+        Ok(validated
+            .into_iter()
+            .filter(|(index, _)| indices.is_empty() || indices.contains(index))
+            .map(|(_, duty)| duty)
+            .collect())
     }
 
     /// Fetches the fork schedule for all known forks.
@@ -690,5 +767,122 @@ mod tests {
             .expect("ok event");
         assert_eq!(second.topic, "chain_reorg");
         assert_eq!(second.data, r#"{"slot":"20","depth":"2"}"#);
+    }
+
+    /// Slots per epoch used by the proposer-duty tests.
+    const TEST_SLOTS_PER_EPOCH: u64 = 8;
+
+    /// A well-formed proposer duty for `index`, proposing at `slot`.
+    fn proposer_duty(index: u64, slot: u64) -> serde_json::Value {
+        serde_json::json!({
+            "pubkey": format!("0x{:096x}", index),
+            "slot": slot.to_string(),
+            "validator_index": index.to_string(),
+        })
+    }
+
+    /// Serves `data` from the epoch-0 proposer-duties endpoint.
+    async fn serve_proposer_duties(data: Vec<serde_json::Value>) -> wiremock::MockServer {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/eth/v1/validator/duties/proposer/0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependent_root": format!("0x{:064x}", 0),
+                "execution_optimistic": false,
+                "data": data,
+            })))
+            .mount(&server)
+            .await;
+
+        server
+    }
+
+    /// An epoch of duties, one per slot, for validators `0..count`.
+    async fn proposer_duties_server(count: u64) -> wiremock::MockServer {
+        serve_proposer_duties((0..count).map(|i| proposer_duty(i, i)).collect()).await
+    }
+
+    #[tokio::test]
+    async fn fetch_proposer_duties_keeps_only_requested_indices() {
+        let server = proposer_duties_server(5).await;
+        let client = EthBeaconNodeApiClient::with_base_url(server.uri()).expect("valid url");
+
+        let duties = client
+            .fetch_proposer_duties(0, TEST_SLOTS_PER_EPOCH, &HashSet::from([1, 3]))
+            .await
+            .expect("fetch duties");
+
+        assert_eq!(
+            duties
+                .iter()
+                .map(|duty| duty.validator_index.as_str())
+                .collect::<Vec<_>>(),
+            ["1", "3"],
+        );
+    }
+
+    /// An empty index set must still yield the whole epoch's proposers.
+    #[tokio::test]
+    async fn fetch_proposer_duties_without_indices_is_unfiltered() {
+        let server = proposer_duties_server(5).await;
+        let client = EthBeaconNodeApiClient::with_base_url(server.uri()).expect("valid url");
+
+        let duties = client
+            .fetch_proposer_duties(0, TEST_SLOTS_PER_EPOCH, &HashSet::new())
+            .await
+            .expect("fetch duties");
+
+        assert_eq!(duties.len(), 5);
+    }
+
+    /// A malformed duty fails the response even when it belongs to a validator
+    /// the caller did not ask about.
+    #[tokio::test]
+    async fn fetch_proposer_duties_rejects_malformed_unrequested_duty() {
+        let mut data = vec![proposer_duty(1, 1)];
+        data.push(serde_json::json!({
+            "pubkey": "0xnot-a-pubkey",
+            "slot": "2",
+            "validator_index": "2",
+        }));
+
+        let server = serve_proposer_duties(data).await;
+        let client = EthBeaconNodeApiClient::with_base_url(server.uri()).expect("valid url");
+
+        // Index 2 is filtered out, but its malformed pubkey must still surface.
+        let err = client
+            .fetch_proposer_duties(0, TEST_SLOTS_PER_EPOCH, &HashSet::from([1]))
+            .await
+            .expect_err("malformed duty should fail the response");
+
+        assert!(
+            matches!(err, EthBeaconNodeApiClientError::ParseError(_)),
+            "expected parse error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_proposer_duties_rejects_duty_outside_requested_epoch() {
+        // Epoch 0 spans slots 0..=7, so slot 9 belongs to another epoch.
+        let server = serve_proposer_duties(vec![proposer_duty(1, 1), proposer_duty(2, 9)]).await;
+        let client = EthBeaconNodeApiClient::with_base_url(server.uri()).expect("valid url");
+
+        let err = client
+            .fetch_proposer_duties(0, TEST_SLOTS_PER_EPOCH, &HashSet::from([1]))
+            .await
+            .expect_err("out-of-epoch duty should fail the response");
+
+        assert!(
+            matches!(
+                err,
+                EthBeaconNodeApiClientError::DutySlotOutsideEpoch { slot: 9, epoch: 0 }
+            ),
+            "expected out-of-epoch error, got {err:?}"
+        );
     }
 }

--- a/crates/eth2api/src/extensions.rs
+++ b/crates/eth2api/src/extensions.rs
@@ -2,8 +2,7 @@ use crate::{
     BeaconStateFork, ConsensusVersion, EthBeaconNodeApiClient, EventstreamRequestQueryTopic,
     GetForkScheduleRequest, GetForkScheduleResponse, GetGenesisRequest, GetGenesisResponse,
     GetGenesisResponseResponseData, GetProposerDutiesRequest, GetProposerDutiesResponse,
-    GetProposerDutiesResponseResponseDatum, GetSpecRequest, GetSpecResponse, ValidatorStatus,
-    spec::phase0,
+    GetSpecRequest, GetSpecResponse, ValidatorStatus, spec::phase0,
 };
 use chrono::{DateTime, Utc};
 use eventsource_stream::Eventsource;
@@ -92,6 +91,17 @@ pub struct ForkSchedule {
     pub version: phase0::Version,
     /// The epoch at which the fork activates.
     pub epoch: phase0::Epoch,
+}
+
+/// A proposer duty with its fields decoded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposerDuty {
+    /// The proposer's BLS public key.
+    pub pubkey: phase0::BLSPubKey,
+    /// Index of the proposer in the validator registry.
+    pub validator_index: phase0::ValidatorIndex,
+    /// The slot at which the validator must propose a block.
+    pub slot: phase0::Slot,
 }
 
 fn required_str_field<'a>(
@@ -366,7 +376,7 @@ impl EthBeaconNodeApiClient {
         epoch: phase0::Epoch,
         slots_per_epoch: u64,
         indices: &HashSet<phase0::ValidatorIndex>,
-    ) -> Result<Vec<GetProposerDutiesResponseResponseDatum>, EthBeaconNodeApiClientError> {
+    ) -> Result<Vec<ProposerDuty>, EthBeaconNodeApiClientError> {
         if slots_per_epoch == 0 {
             return Err(EthBeaconNodeApiClientError::ZeroSlotDurationOrSlotsPerEpoch);
         }
@@ -386,7 +396,7 @@ impl EthBeaconNodeApiClient {
         // validator we did not ask about.
         let mut validated = Vec::with_capacity(duties.len());
         for duty in duties {
-            let index = duty
+            let validator_index = duty
                 .validator_index
                 .parse::<phase0::ValidatorIndex>()
                 .map_err(|_| {
@@ -395,7 +405,7 @@ impl EthBeaconNodeApiClient {
             let slot = duty.slot.parse::<phase0::Slot>().map_err(|_| {
                 EthBeaconNodeApiClientError::ParseError("proposer duty slot".into())
             })?;
-            let _: phase0::BLSPubKey =
+            let pubkey =
                 decode_fixed_hex(&duty.pubkey, || "decode proposer duty pubkey".to_string())?;
 
             // Reject duties outside the requested epoch. Comparing epochs
@@ -408,13 +418,16 @@ impl EthBeaconNodeApiClient {
                 return Err(EthBeaconNodeApiClientError::DutySlotOutsideEpoch { slot, epoch });
             }
 
-            validated.push((index, duty));
+            validated.push(ProposerDuty {
+                pubkey,
+                validator_index,
+                slot,
+            });
         }
 
         Ok(validated
             .into_iter()
-            .filter(|(index, _)| indices.is_empty() || indices.contains(index))
-            .map(|(_, duty)| duty)
+            .filter(|duty| indices.is_empty() || indices.contains(&duty.validator_index))
             .collect())
     }
 
@@ -820,9 +833,9 @@ mod tests {
         assert_eq!(
             duties
                 .iter()
-                .map(|duty| duty.validator_index.as_str())
+                .map(|duty| duty.validator_index)
                 .collect::<Vec<_>>(),
-            ["1", "3"],
+            [1, 3],
         );
     }
 


### PR DESCRIPTION
Fix https://github.com/NethermindEth/pluto/issues/565

This should be included in the MVP since there are many warn logs 

<img width="843" height="535" alt="image" src="https://github.com/user-attachments/assets/43f67a13-8b1b-4ed5-bdbe-436d43e375c4" />
