### PR TITLE
fix(dkg): flanky test keymanager

### DIFF
--- a/crates/dkg/src/dkg.rs
+++ b/crates/dkg/src/dkg.rs
@@ -1214,16 +1214,12 @@ mod tests {
 
     #[tokio::test]
     async fn verify_keymanager_connection_fails_for_unreachable_address() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("listener should bind");
-        let addr = format!("http://{}", listener.local_addr().expect("local addr"));
-        drop(listener);
-
+        // Destination port 0 is never assigned to a listener, so connecting to it
+        // fails without racing on a probed-then-released ephemeral port.
         let config = Config::builder()
             .keymanager(
                 KeymanagerConfig::builder()
-                    .address(addr)
+                    .address("http://127.0.0.1:0".to_string())
                     .auth_token("token".to_string())
                     .build(),
             )


### PR DESCRIPTION
## Problem

  `dkg::tests::verify_keymanager_connection_fails_for_unreachable_address` is flaky under parallel test runs. It binds `127.0.0.1:0` to get an ephemeral port, drops the listener, then connects expecting failure. Between release and connect, the kernel can hand the same port to another process (e.g. a concurrent test suite binding `:0`); since the production check is TCP-handshake-only, the connection succeeds and the test fails with `unreachable keymanager should fail`.

  ## Solution

  Dial `http://127.0.0.1:0` directly. Port 0 is only meaningful as a bind request ("assign me a port") and is never assigned to a listener, so as a connect destination it fails unconditionally — no probe-then-release window, no port for a competing process to occupy. Deterministic by construction; no retries, sleeps, or serialization. Test-only change; the `DkgError::Keymanager` assertion is preserved.